### PR TITLE
# LAN Scanner Feature Walkthrough

### DIFF
--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -1,6 +1,6 @@
 # Project Summary: NTP DIG PING MORE
 
-A modern, material-design Android application for professional network diagnostics, featuring NTP, DNS (DIG), Ping, Traceroute, and Port Scanning.
+A modern, material-design Android application for professional network diagnostics, featuring NTP, DNS (DIG), Ping, Traceroute, Port Scanning, LAN Scanning, and Google Time Sync.
 
 ## Tech Stack
 
@@ -11,7 +11,7 @@ A modern, material-design Android application for professional network diagnosti
 | **Architecture** | MVVM (ViewModel + StateFlow) |
 | **Navigation** | Jetpack Navigation Compose |
 | **Concurrency** | Kotlin Coroutines (`Dispatchers.IO`) |
-| **Networking** | Apache Commons Net (`NTPUDPClient`), dnsjava (`SimpleResolver`) |
+| **Networking** | Apache Commons Net (`NTPUDPClient`), dnsjava (`SimpleResolver`), `HttpURLConnection` (Google Time Sync) |
 | **Persistence** | AndroidX Preferences DataStore |
 | **Build System** | Gradle (Kotlin DSL) |
 | **Min SDK** | 26 (Android 8.0) |
@@ -24,6 +24,8 @@ A modern, material-design Android application for professional network diagnosti
 - **📡 Ping**: Live ICMP ping stream with real-time MONOSPACE terminal output and success/failure history tracking.
 - **🛤 Traceroute**: Hop-by-hop network path discovery implemented via TTL-probing ICMP packets.
 - **🕵️ Port Scanner**: Concurrent TCP/UDP port range scanning with live progress and discovery logs.
+- **🖥️ LAN Scanner**: Subnet device discovery with IP, hostname, MAC, and latency; custom range scanning.
+- **🌐 Google Time Sync**: Queries `http://clients2.google.com/time/1/current`, strips the XSSI prefix, and computes RTT, clock offset, and corrected server time using T1/T4 timestamps.
 - **📚 Persistence**: Persistent query history for all tools (last 5 entries) using DataStore.
 
 ## Core Views & Screens
@@ -35,7 +37,9 @@ All views follow a consistent Material 3 design with dark mode support and monos
 - **Ping Screen**: Target input, Live Monospace Terminal card, Start/Stop toggle, and history.
 - **Traceroute Screen**: Target input, Hop-by-hop streaming terminal, and history.
 - **Port Scanner Screen**: Target/Range input, Protocol toggle, Progress bar, and open port list.
-- **Navigation**: Bottom Navigation Bar for quick switching between diagnostics tools.
+- **LAN Scanner Screen**: Subnet sweep with live device list (IP, hostname, MAC, latency).
+- **Google Time Sync Screen**: Host input, animated result card with color-coded offset (🟢/🟠/🔴), corrected server time, and one-tap copy-offset button.
+- **Navigation**: Bottom Navigation Bar for quick switching between diagnostics tools. Traceroute, Port Scanner, LAN Scanner, and Google Time Sync are accessible via the **More** overflow screen.
 
 ## Project Structure
 
@@ -53,3 +57,4 @@ app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/
 - `libs.commons.net`: Used for NTP UDP packet exchange.
 - `libs.dnsjava`: Used for complex DNS resolution bypassing system resolver.
 - `androidx.datastore.preferences`: Lightweight persistence for user query history.
+- `java.net.HttpURLConnection`: Used for the Google Time Sync HTTP request (no extra dependency; XSSI prefix stripped before JSON parsing via `org.json`).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Network Utilities Checker
 
-A modern Android app for network diagnostics, providing **NTP reachability testing**, **DNS lookup (DIG)**, **Ping**, and **Traceroute**.
+A modern Android app for network diagnostics: **NTP reachability testing**, **DNS lookup (DIG)**, **Ping**, **Traceroute**, **Port Scanner**, **LAN Scanner**, and **Google Time Sync**.
 
 ## Visuals
 
@@ -84,6 +84,18 @@ connect.hostinger.com.   120  IN  A      34.120.137.41
 - Tracks scan progress with a stop/cancel capability
 - History of past scans persisted across app restarts
 
+### 🌐 Google Time Sync
+- Queries `http://clients2.google.com/time/1/current` over HTTP and parses Google's time response
+- Strips the `)]}'` XSSI protection prefix before JSON parsing
+- Computes full NTP-style time synchronisation metrics:
+  - 📡 **RTT** — round-trip time (T4 − T1)
+  - ⏱ **Clock Offset** — `correctedServerTime − T4` (positive = local clock behind, negative = ahead)
+  - 🧮 **Corrected Server Time** — `serverTime + RTT / 2`
+- Color-coded offset indicator: 🟢 < 100 ms · 🟠 < 500 ms · 🔴 ≥ 500 ms
+- Custom host field (defaults to `clients2.google.com`)
+- One-tap **Copy Offset** button for manual clock-adjustment workflows
+- Idle / Loading / Success / Error states survive rotation and config changes
+
 ## Stack
 
 | Layer | Technology |
@@ -103,28 +115,31 @@ connect.hostinger.com.   120  IN  A      34.120.137.41
 
 ```
 app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/
-├── MainActivity.kt          # NavHost, bottom navigation bar, NTP screen UI
-├── MoreToolsScreen.kt       # Overflow screen for Traceroute, Port Scanner, LAN Scanner
-├── NtpRepository.kt         # NTP network I/O (NTPUDPClient, sealed NtpResult)
-├── NtpViewModel.kt          # NTP UI state (StateFlow<NtpUiState>), coroutine lifecycle
-├── NtpHistoryStore.kt       # DataStore persistence for NTP query history
-├── DigScreen.kt             # DIG test screen composable
-├── DigViewModel.kt          # DIG UI state, delegates to DigRepository
-├── DigRepository.kt         # DNS resolution via dnsjava SimpleResolver
-├── PingScreen.kt            # Ping screen composable
-├── PingViewModel.kt         # Ping UI state, process lifecycle, three-state status
-├── PingHistoryStore.kt      # DataStore persistence for Ping history
-├── TracerouteScreen.kt      # Traceroute screen composable
-├── TracerouteViewModel.kt   # TTL-probing traceroute via ping, hop parsing, status
-├── TracerouteHistoryStore.kt# DataStore persistence for Traceroute history
-├── PortScannerScreen.kt     # Port Scanner screen composable
-├── PortScannerViewModel.kt  # Port Scanner UI state, concurrent scanning logic
-├── PortScannerHistoryStore.kt# DataStore persistence for Port Scanner history
-├── LanScannerScreen.kt      # LAN Scanner screen composable
-├── LanScannerViewModel.kt   # LAN Scanner UI state, concurrent ping/ARP sweep
-├── LanScannerRepository.kt  # Networking logic, subnet detection, ARP parsing
-├── LanScannerHistoryStore.kt# DataStore persistence for LAN Scanner history
-└── ui/theme/                # Material 3 colors, typography, theme
+├── MainActivity.kt              # NavHost, bottom navigation bar, NTP screen UI
+├── MoreToolsScreen.kt           # Overflow screen: Traceroute, Port Scanner, LAN Scanner, Google Time Sync
+├── NtpRepository.kt             # NTP network I/O (NTPUDPClient, sealed NtpResult)
+├── NtpViewModel.kt              # NTP UI state (StateFlow<NtpUiState>), coroutine lifecycle
+├── NtpHistoryStore.kt           # DataStore persistence for NTP query history
+├── DigScreen.kt                 # DIG test screen composable
+├── DigViewModel.kt              # DIG UI state, delegates to DigRepository
+├── DigRepository.kt             # DNS resolution via dnsjava SimpleResolver
+├── PingScreen.kt                # Ping screen composable
+├── PingViewModel.kt             # Ping UI state, process lifecycle, three-state status
+├── PingHistoryStore.kt          # DataStore persistence for Ping history
+├── TracerouteScreen.kt          # Traceroute screen composable
+├── TracerouteViewModel.kt       # TTL-probing traceroute via ping, hop parsing, status
+├── TracerouteHistoryStore.kt    # DataStore persistence for Traceroute history
+├── PortScannerScreen.kt         # Port Scanner screen composable
+├── PortScannerViewModel.kt      # Port Scanner UI state, concurrent scanning logic
+├── PortScannerHistoryStore.kt   # DataStore persistence for Port Scanner history
+├── LanScannerScreen.kt          # LAN Scanner screen composable
+├── LanScannerViewModel.kt       # LAN Scanner UI state, concurrent ping/ARP sweep
+├── LanScannerRepository.kt      # Networking logic, subnet detection, ARP parsing
+├── LanScannerHistoryStore.kt    # DataStore persistence for LAN Scanner history
+├── GoogleTimeSyncRepository.kt  # HTTP fetch, XSSI strip, JSON parse, T1/T4 offset calc
+├── GoogleTimeSyncViewModel.kt   # Idle/Loading/Success/Error StateFlow, syncTime() & reset()
+├── GoogleTimeSyncScreen.kt      # Google Time Sync screen composable
+└── ui/theme/                    # Material 3 colors, typography, theme
 ```
 
 ## Requirements
@@ -161,14 +176,18 @@ adb shell am start -n io.github.mobilutils.ntp_dig_ping_more/.MainActivity
 
 Only `INTERNET` and `ACCESS_NETWORK_STATE` are required. No location, storage, or other sensitive permissions are used.
 
+> **Note:** `android:usesCleartextTraffic="true"` is set in `AndroidManifest.xml` because the Google Time Sync endpoint (`http://clients2.google.com/time/1/current`) is served over plain HTTP. All other features use HTTPS or non-HTTP protocols (UDP/ICMP/TCP sockets).
+
 ## Error States
 
 | Error | Cause |
 |---|---|
 | DNS Failure | Hostname could not be resolved |
 | NXDOMAIN | Queried name does not exist |
-| Timeout | Server did not respond within 5 seconds |
+| Timeout | Server did not respond within the timeout window |
 | No Network | Device has no active internet connection |
+| HTTP Error | Non-200 response from the Google Time endpoint |
+| Parse Error | Response body missing XSSI prefix or invalid JSON |
 | Error | Any other unexpected exception |
 
 ## License

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "io.github.mobilutils.ntp_dig_ping_more"
         minSdk = 26
         targetSdk { version = release(rootProject.extra["defaultTargetSdkVersion"] as Int) }
-        versionCode = 5
-        versionName = "2.2"
+        versionCode = 6
+        versionName = "2.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/Theme.NtpDigPingMore">
 
         <activity

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/GoogleTimeSyncRepository.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/GoogleTimeSyncRepository.kt
@@ -1,0 +1,174 @@
+package io.github.mobilutils.ntp_dig_ping_more
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.SocketTimeoutException
+import java.net.URL
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain model
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Holds all time-sync data computed from a single successful exchange
+ * with the Google time endpoint.
+ *
+ * @param serverTimeMillis          Raw `current_time_millis` from the JSON response (UTC epoch ms).
+ * @param rttMillis                 Round-trip time: T4 − T1 (ms).
+ * @param offsetMillis              correctedServerTime − T4 (ms).
+ *                                  Positive → local clock is behind the server.
+ *                                  Negative → local clock is ahead.
+ * @param correctedServerTimeMillis serverTime + RTT / 2 (ms).
+ * @param requestTimestamp          T1: client timestamp just before the request (ms).
+ * @param responseTimestamp         T4: client timestamp when the response was received (ms).
+ */
+data class TimeSyncResult(
+    val serverTimeMillis: Long,
+    val rttMillis: Long,
+    val offsetMillis: Long,
+    val correctedServerTimeMillis: Long,
+    val requestTimestamp: Long,
+    val responseTimestamp: Long,
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Result sealed hierarchy
+// ─────────────────────────────────────────────────────────────────────────────
+
+sealed class GoogleTimeSyncResult {
+    data class Success(val data: TimeSyncResult) : GoogleTimeSyncResult()
+    data object NoNetwork : GoogleTimeSyncResult()
+    data class Timeout(val host: String) : GoogleTimeSyncResult()
+    data class HttpError(val code: Int, val host: String) : GoogleTimeSyncResult()
+    data class ParseError(val message: String) : GoogleTimeSyncResult()
+    data class Error(val message: String) : GoogleTimeSyncResult()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Repository
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Fetches the current UTC time from Google's time-sync endpoint and computes
+ * the clock offset between the local device and the server.
+ *
+ * Endpoint: `GET http://<host>/time/1/current`
+ * The response is prefixed with `)]}'` (XSSI protection) which is stripped
+ * before JSON parsing.
+ */
+class GoogleTimeSyncRepository {
+
+    companion object {
+        private const val PATH               = "/time/1/current"
+        private const val CONNECT_TIMEOUT_MS = 10_000  // 10 s
+        private const val READ_TIMEOUT_MS    = 15_000  // 15 s
+
+        /** Number of characters in the XSSI prefix: )]}'  */
+        private const val XSSI_PREFIX_LEN   = 4
+    }
+
+    /**
+     * Performs a synchronous HTTP GET on the IO dispatcher.
+     * Safe to call from any coroutine scope.
+     *
+     * @param host  Hostname to query (default: `clients2.google.com`).
+     */
+    suspend fun fetchGoogleTime(
+        host: String = "clients2.google.com",
+    ): GoogleTimeSyncResult = withContext(Dispatchers.IO) {
+
+        val url = "http://$host$PATH"
+        var connection: HttpURLConnection? = null
+
+        try {
+            // T1: record timestamp BEFORE the request goes out.
+            val t1 = System.currentTimeMillis()
+
+            connection = (URL(url).openConnection() as HttpURLConnection).apply {
+                requestMethod        = "GET"
+                connectTimeout       = CONNECT_TIMEOUT_MS
+                readTimeout          = READ_TIMEOUT_MS
+                instanceFollowRedirects = true
+                setRequestProperty("Accept", "application/json")
+            }
+
+            val responseCode = connection.responseCode
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                return@withContext GoogleTimeSyncResult.HttpError(responseCode, host)
+            }
+
+            val rawBody = connection.inputStream.bufferedReader(Charsets.UTF_8).readText()
+
+            // T4: record timestamp AFTER the response body is fully read.
+            val t4 = System.currentTimeMillis()
+
+            // ── Strip XSSI prefix ────────────────────────────────────────
+            if (rawBody.length < XSSI_PREFIX_LEN) {
+                return@withContext GoogleTimeSyncResult.ParseError(
+                    "Response body too short to contain XSSI prefix (got ${rawBody.length} chars)"
+                )
+            }
+            val jsonStr = rawBody.substring(XSSI_PREFIX_LEN).trim()
+
+            // ── Parse JSON ───────────────────────────────────────────────
+            val json = try {
+                JSONObject(jsonStr)
+            } catch (e: Exception) {
+                return@withContext GoogleTimeSyncResult.ParseError(
+                    "Malformed JSON: ${e.localizedMessage}"
+                )
+            }
+
+            if (!json.has("current_time_millis")) {
+                return@withContext GoogleTimeSyncResult.ParseError(
+                    "Missing field: current_time_millis"
+                )
+            }
+            val serverTimeMillis = json.getLong("current_time_millis")
+
+            // ── Time-sync calculation ────────────────────────────────────
+            // RTT = T4 − T1
+            val rtt = t4 - t1
+            // correctedServerTime = serverTime + RTT / 2
+            val correctedServerTime = serverTimeMillis + (rtt / 2L)
+            // offset = correctedServerTime − T4
+            // Positive  → local clock is behind
+            // Negative  → local clock is ahead
+            val offset = correctedServerTime - t4
+
+            GoogleTimeSyncResult.Success(
+                TimeSyncResult(
+                    serverTimeMillis          = serverTimeMillis,
+                    rttMillis                 = rtt,
+                    offsetMillis              = offset,
+                    correctedServerTimeMillis = correctedServerTime,
+                    requestTimestamp          = t1,
+                    responseTimestamp         = t4,
+                )
+            )
+
+        } catch (e: SocketTimeoutException) {
+            GoogleTimeSyncResult.Timeout(host)
+
+        } catch (e: IOException) {
+            val msg = e.message.orEmpty()
+            if (msg.contains("unreachable", ignoreCase = true) ||
+                msg.contains("connect failed", ignoreCase = true) ||
+                msg.contains("network", ignoreCase = true)
+            ) {
+                GoogleTimeSyncResult.NoNetwork
+            } else {
+                GoogleTimeSyncResult.Error(e.localizedMessage ?: "Network error")
+            }
+
+        } catch (e: Exception) {
+            GoogleTimeSyncResult.Error(e.localizedMessage ?: "Unknown error")
+
+        } finally {
+            connection?.disconnect()
+        }
+    }
+}

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/GoogleTimeSyncScreen.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/GoogleTimeSyncScreen.kt
@@ -1,0 +1,484 @@
+package io.github.mobilutils.ntp_dig_ping_more
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Adjust
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.SwapHoriz
+import androidx.compose.material.icons.filled.Sync
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.delay
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import kotlin.math.abs
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Root screen
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Composable
+fun GoogleTimeSyncScreen(
+    vm: GoogleTimeSyncViewModel = viewModel(),
+) {
+    val uiState  by vm.uiState.collectAsState()
+    val focusManager      = LocalFocusManager.current
+    val clipboardManager  = LocalClipboardManager.current
+
+    var host    by remember { mutableStateOf("clients2.google.com") }
+    var copied  by remember { mutableStateOf(false) }
+
+    // Auto-reset the "Copied!" label after 2 s.
+    LaunchedEffect(copied) {
+        if (copied) {
+            delay(2_000)
+            copied = false
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp, vertical = 20.dp)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // ── Description ───────────────────────────────────────────────
+        Text(
+            text = "Query clients2.google.com for UTC time with offset calculation",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        // ── Host field ────────────────────────────────────────────────
+        OutlinedTextField(
+            value = host,
+            onValueChange = { newValue ->
+                host = newValue
+                // Clear any displayed result when the host is edited.
+                if (uiState !is GoogleTimeSyncUiState.Idle) vm.reset()
+            },
+            label         = { Text("Host") },
+            placeholder   = { Text("clients2.google.com") },
+            singleLine    = true,
+            modifier      = Modifier.fillMaxWidth(),
+            leadingIcon   = { Icon(Icons.Filled.Language,  contentDescription = null) },
+            trailingIcon  = {
+                if (host.isNotEmpty()) {
+                    IconButton(onClick = {
+                        host = ""
+                        vm.reset()
+                    }) {
+                        Icon(Icons.Filled.Clear, contentDescription = "Clear host")
+                    }
+                }
+            },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Uri,
+                imeAction    = ImeAction.Go,
+            ),
+            keyboardActions = KeyboardActions(
+                onGo = {
+                    focusManager.clearFocus()
+                    vm.syncTime(host)
+                }
+            ),
+        )
+
+        // ── Sync button ───────────────────────────────────────────────
+        Button(
+            onClick = {
+                focusManager.clearFocus()
+                vm.syncTime(host)
+            },
+            enabled  = uiState !is GoogleTimeSyncUiState.Loading && host.isNotBlank(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(52.dp),
+            shape  = RoundedCornerShape(12.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+            ),
+        ) {
+            if (uiState is GoogleTimeSyncUiState.Loading) {
+                CircularProgressIndicator(
+                    modifier    = Modifier.size(20.dp),
+                    strokeWidth = 2.dp,
+                    color       = MaterialTheme.colorScheme.onPrimary,
+                )
+                Spacer(Modifier.width(8.dp))
+                Text("Syncing…")
+            } else {
+                Icon(
+                    Icons.Filled.Sync,
+                    contentDescription = null,
+                    modifier           = Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(8.dp))
+                Text("Sync Now", fontWeight = FontWeight.Medium)
+            }
+        }
+
+        // ── Result ────────────────────────────────────────────────────
+        AnimatedVisibility(
+            visible = uiState is GoogleTimeSyncUiState.Success ||
+                      uiState is GoogleTimeSyncUiState.Error,
+            enter   = fadeIn(tween(300)) + slideInVertically(tween(300)) { it / 3 },
+            exit    = fadeOut(tween(200)),
+        ) {
+            when (val state = uiState) {
+                is GoogleTimeSyncUiState.Success -> {
+                    TimeSyncResultCard(
+                        result   = state.result,
+                        copied   = copied,
+                        onCopy   = {
+                            val offsetSign = if (state.result.offsetMillis >= 0) "+" else ""
+                            clipboardManager.setText(
+                                AnnotatedString("$offsetSign${state.result.offsetMillis} ms")
+                            )
+                            copied = true
+                        },
+                    )
+                }
+                is GoogleTimeSyncUiState.Error -> {
+                    ErrorCard(
+                        message = state.message,
+                        onRetry = { vm.syncTime(host) },
+                    )
+                }
+                else -> { /* Idle / Loading — nothing to show */ }
+            }
+        }
+
+        // ── Footer helper text ────────────────────────────────────────
+        Text(
+            text  = "Offset = corrected server time − your device time",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+        )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Success card
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun TimeSyncResultCard(
+    result: TimeSyncResult,
+    copied: Boolean,
+    onCopy: () -> Unit,
+) {
+    val offsetAbs = abs(result.offsetMillis)
+
+    // Color-code the offset: green < 100 ms, orange < 500 ms, red ≥ 500 ms.
+    val offsetColor = when {
+        offsetAbs < 100L -> MaterialTheme.colorScheme.secondary
+        offsetAbs < 500L -> Color(0xFFE65100) // deep-orange
+        else             -> MaterialTheme.colorScheme.error
+    }
+
+    val offsetSign  = if (result.offsetMillis >= 0) "+" else ""
+    val offsetLabel = when {
+        result.offsetMillis > 0L -> "Local clock is behind server"
+        result.offsetMillis < 0L -> "Local clock is ahead of server"
+        else                     -> "Clocks are in sync"
+    }
+
+    val utcFormatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US).apply {
+        timeZone = TimeZone.getTimeZone("UTC")
+    }
+    val serverTimeStr    = utcFormatter.format(Date(result.serverTimeMillis))    + " UTC"
+    val correctedTimeStr = utcFormatter.format(Date(result.correctedServerTimeMillis)) + " UTC"
+
+    Card(
+        modifier  = Modifier.fillMaxWidth(),
+        shape     = RoundedCornerShape(16.dp),
+        colors    = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+
+            // Header
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector        = Icons.Filled.CheckCircle,
+                    contentDescription = "Success",
+                    tint               = MaterialTheme.colorScheme.secondary,
+                    modifier           = Modifier.size(32.dp),
+                )
+                Spacer(Modifier.width(12.dp))
+                Column {
+                    Text(
+                        text       = "Sync Successful",
+                        style      = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Text(
+                        text  = "RTT ${result.rttMillis} ms  ·  offset $offsetSign${result.offsetMillis} ms",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+            HorizontalDivider(
+                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.2f)
+            )
+            Spacer(Modifier.height(16.dp))
+
+            // Server time
+            SyncMetricRow(
+                icon  = Icons.Filled.Schedule,
+                label = "Server Time",
+                value = serverTimeStr,
+            )
+            Spacer(Modifier.height(10.dp))
+
+            // RTT
+            SyncMetricRow(
+                icon  = Icons.Filled.SwapHoriz,
+                label = "Round-Trip Time",
+                value = "${result.rttMillis} ms",
+            )
+            Spacer(Modifier.height(10.dp))
+
+            // Clock offset (colour-coded with descriptive sub-label)
+            Row(
+                modifier             = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment    = Alignment.Top,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier          = Modifier.weight(1f),
+                ) {
+                    Icon(
+                        imageVector        = Icons.Filled.Timer,
+                        contentDescription = null,
+                        tint               = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier           = Modifier.size(18.dp),
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text  = "Clock Offset",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Column(
+                    horizontalAlignment = Alignment.End,
+                    modifier            = Modifier.weight(1.5f),
+                ) {
+                    Text(
+                        text       = "$offsetSign${result.offsetMillis} ms",
+                        style      = MaterialTheme.typography.bodyMedium.copy(
+                            fontFamily = FontFamily.Monospace
+                        ),
+                        fontWeight = FontWeight.Bold,
+                        color      = offsetColor,
+                    )
+                    Text(
+                        text  = offsetLabel,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = offsetColor.copy(alpha = 0.8f),
+                    )
+                }
+            }
+            Spacer(Modifier.height(10.dp))
+
+            // Corrected time
+            SyncMetricRow(
+                icon  = Icons.Filled.Adjust,
+                label = "Corrected Time",
+                value = correctedTimeStr,
+            )
+
+            Spacer(Modifier.height(16.dp))
+            HorizontalDivider(
+                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.2f)
+            )
+            Spacer(Modifier.height(12.dp))
+
+            // Copy offset button
+            OutlinedButton(
+                onClick  = onCopy,
+                modifier = Modifier.fillMaxWidth(),
+                shape    = RoundedCornerShape(10.dp),
+            ) {
+                Icon(
+                    imageVector        = if (copied) Icons.Filled.CheckCircle
+                                        else          Icons.Filled.ContentCopy,
+                    contentDescription = null,
+                    modifier           = Modifier.size(16.dp),
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    if (copied) "Copied!"
+                    else        "Copy Offset ($offsetSign${result.offsetMillis} ms)"
+                )
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error card
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun ErrorCard(
+    message: String,
+    onRetry: () -> Unit,
+) {
+    Card(
+        modifier  = Modifier.fillMaxWidth(),
+        shape     = RoundedCornerShape(16.dp),
+        colors    = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+    ) {
+        Column(modifier = Modifier.padding(20.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector        = Icons.Filled.Error,
+                    contentDescription = "Error",
+                    tint               = MaterialTheme.colorScheme.error,
+                    modifier           = Modifier.size(32.dp),
+                )
+                Spacer(Modifier.width(12.dp))
+                Column {
+                    Text(
+                        text       = "Sync Failed",
+                        style      = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color      = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                    Text(
+                        text  = message,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.8f),
+                    )
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+            OutlinedButton(
+                onClick  = onRetry,
+                modifier = Modifier.fillMaxWidth(),
+                shape    = RoundedCornerShape(10.dp),
+                colors   = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                ),
+            ) {
+                Icon(Icons.Filled.Refresh, contentDescription = null, modifier = Modifier.size(16.dp))
+                Spacer(Modifier.width(6.dp))
+                Text("Retry")
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reusable metric row (icon + label + monospace value)
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Composable
+private fun SyncMetricRow(
+    icon: ImageVector,
+    label: String,
+    value: String,
+) {
+    Row(
+        modifier              = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment     = Alignment.Top,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier          = Modifier.weight(1f),
+        ) {
+            Icon(
+                imageVector        = icon,
+                contentDescription = null,
+                tint               = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier           = Modifier.size(18.dp),
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text  = label,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Text(
+            text       = value,
+            style      = MaterialTheme.typography.bodyMedium.copy(
+                fontFamily = FontFamily.Monospace
+            ),
+            fontWeight = FontWeight.Medium,
+            modifier   = Modifier.weight(1.5f),
+        )
+    }
+}

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/GoogleTimeSyncViewModel.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/GoogleTimeSyncViewModel.kt
@@ -1,0 +1,82 @@
+package io.github.mobilutils.ntp_dig_ping_more
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+// ─────────────────────────────────────────────────────────────────────────────
+// UI state
+// ─────────────────────────────────────────────────────────────────────────────
+
+sealed class GoogleTimeSyncUiState {
+    /** No sync has been attempted yet (or state was reset). */
+    data object Idle : GoogleTimeSyncUiState()
+
+    /** A sync request is currently in-flight. */
+    data object Loading : GoogleTimeSyncUiState()
+
+    /** The sync completed successfully. */
+    data class Success(val result: TimeSyncResult) : GoogleTimeSyncUiState()
+
+    /** The sync failed for any reason. */
+    data class Error(val message: String) : GoogleTimeSyncUiState()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ViewModel
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * ViewModel for the Google Time Sync screen.
+ *
+ * Survives configuration changes and cancels any in-flight request
+ * automatically when [onCleared] is called.
+ */
+class GoogleTimeSyncViewModel(
+    private val repository: GoogleTimeSyncRepository = GoogleTimeSyncRepository(),
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<GoogleTimeSyncUiState>(GoogleTimeSyncUiState.Idle)
+    val uiState: StateFlow<GoogleTimeSyncUiState> = _uiState.asStateFlow()
+
+    private var syncJob: Job? = null
+
+    /**
+     * Launches a time-sync request against [host].
+     *
+     * Any previously running request is cancelled before the new one starts.
+     *
+     * @param host  Hostname to query (e.g. `clients2.google.com`).
+     */
+    fun syncTime(host: String) {
+        val trimmedHost = host.trim()
+        if (trimmedHost.isEmpty()) return
+
+        syncJob?.cancel()
+        _uiState.value = GoogleTimeSyncUiState.Loading
+
+        syncJob = viewModelScope.launch {
+            val result = repository.fetchGoogleTime(trimmedHost)
+            _uiState.value = when (result) {
+                is GoogleTimeSyncResult.Success    -> GoogleTimeSyncUiState.Success(result.data)
+                is GoogleTimeSyncResult.NoNetwork  -> GoogleTimeSyncUiState.Error("No network connection")
+                is GoogleTimeSyncResult.Timeout    -> GoogleTimeSyncUiState.Error("Request timed out (host: ${result.host})")
+                is GoogleTimeSyncResult.HttpError  -> GoogleTimeSyncUiState.Error("HTTP error ${result.code} from ${result.host}")
+                is GoogleTimeSyncResult.ParseError -> GoogleTimeSyncUiState.Error("Parse error: ${result.message}")
+                is GoogleTimeSyncResult.Error      -> GoogleTimeSyncUiState.Error(result.message)
+            }
+        }
+    }
+
+    /**
+     * Cancels any in-flight request and returns the UI to the [GoogleTimeSyncUiState.Idle] state.
+     */
+    fun reset() {
+        syncJob?.cancel()
+        _uiState.value = GoogleTimeSyncUiState.Idle
+    }
+}

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/MainActivity.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/MainActivity.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.Route
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material.icons.filled.WifiOff
+import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.WifiFind
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -90,8 +91,9 @@ sealed class AppScreen(
     object Ping        : AppScreen("ping",        "Ping",       Icons.Filled.Terminal)
     object Traceroute  : AppScreen("traceroute",  "Traceroute", Icons.Filled.Route)
     object PortScanner : AppScreen("port_scanner", "Port Scan", Icons.Filled.Search)
-    object LanScanner  : AppScreen("lan_scanner", "LAN Scan",   Icons.Filled.WifiFind)
-    object MoreTools   : AppScreen("more_tools",  "More",       Icons.Filled.MoreHoriz)
+    object LanScanner     : AppScreen("lan_scanner",      "LAN Scan",         Icons.Filled.WifiFind)
+    object GoogleTimeSync : AppScreen("google_time_sync", "Google Time Sync", Icons.Filled.AccessTime)
+    object MoreTools      : AppScreen("more_tools",       "More",             Icons.Filled.MoreHoriz)
 }
 
 private val allAppScreens = listOf(
@@ -101,6 +103,7 @@ private val allAppScreens = listOf(
     AppScreen.Traceroute,
     AppScreen.PortScanner,
     AppScreen.LanScanner,
+    AppScreen.GoogleTimeSync,
     AppScreen.MoreTools,
 )
 
@@ -171,6 +174,7 @@ fun AppRoot() {
                         AppScreen.Traceroute.route,
                         AppScreen.PortScanner.route,
                         AppScreen.LanScanner.route,
+                        AppScreen.GoogleTimeSync.route,
                         AppScreen.MoreTools.route
                     )
                     val selected = currentDest?.hierarchy?.any { it.route == screen.route } == true || isMoreToolsSelected
@@ -225,6 +229,9 @@ fun AppRoot() {
             }
             composable(AppScreen.LanScanner.route) {
                 LanScannerScreen()
+            }
+            composable(AppScreen.GoogleTimeSync.route) {
+                GoogleTimeSyncScreen()
             }
             composable(AppScreen.MoreTools.route) {
                 MoreToolsScreen(

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/MoreToolsScreen.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/MoreToolsScreen.kt
@@ -19,7 +19,8 @@ fun MoreToolsScreen(
     val extraTools = listOf(
         AppScreen.Traceroute,
         AppScreen.PortScanner,
-        AppScreen.LanScanner
+        AppScreen.LanScanner,
+        AppScreen.GoogleTimeSync,
     )
 
     LazyColumn(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">NTP DIG PING MORE</string>
+
+    <!-- Google Time Sync screen -->
+    <string name="google_time_sync_title">Google Time Sync</string>
+    <string name="google_time_sync_subtitle">Query clients2.google.com for UTC time with offset calculation</string>
+    <string name="google_time_sync_button_sync">Sync Now</string>
+    <string name="google_time_sync_label_server_time">Server Time</string>
+    <string name="google_time_sync_label_rtt">Round-Trip Time</string>
+    <string name="google_time_sync_label_offset">Clock Offset</string>
+    <string name="google_time_sync_label_corrected">Corrected Time</string>
+    <string name="google_time_sync_helper">Offset = corrected server time − your device time</string>
+    <string name="google_time_sync_copy_offset">Copy Offset</string>
+    <string name="google_time_sync_copied">Copied!</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.0.1"
+agp = "9.1.1"
 kotlin = "2.2.10"
 coreKtx = "1.15.0"
 junit = "4.13.2"

--- a/notes/202603_LAN Scanner_walkthrough.md
+++ b/notes/202603_LAN Scanner_walkthrough.md
@@ -1,0 +1,43 @@
+# LAN Scanner Feature Walkthrough
+
+The LAN Scanner feature has been successfully implemented and integrated into the `NTP DIG PING MORE` app! 
+
+## Changes Made
+
+### 1. Data Layer ([LanScannerRepository.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/LanScannerRepository.kt) & [LanScannerHistoryStore.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/LanScannerHistoryStore.kt))
+- Added network utilities to detect the active WiFi/Ethernet connection, calculating the subnet mask, base IP, and CIDR.
+- Implemented [ping()](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/LanScannerRepository.kt#75-102) using the native native `ping -c 1 -W 1` command to quickly check if a host is alive, extracting the latency in `ms`.
+- Added reverse DNS lookup functionality to display the hostname if available.
+- Added ARP table reading from `/proc/net/arp` to fetch the true MAC address of discovered devices.
+- Integrated [LanScannerHistoryStore](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/LanScannerHistoryStore.kt#23-68) using Jetpack DataStore to persist recent scan metadata.
+
+### 2. Presentation Layer ([LanScannerViewModel.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/LanScannerViewModel.kt))
+- Created a Coroutine-powered ViewModel that chunks IP scanning into batches to ensure the UI remains responsive and the network isn't flooded.
+- Tracks `progress` from 0.0 to 1.0, updating the UI whenever an IP check finishes.
+- Identifies the gateway (usually `.1`) and highlights it as a "Router" vs a regular "Device".
+- Safely cancels in-flight Coroutines if the user presses "Stop Scan" or navigates away.
+
+### 3. UI Layer ([LanScannerScreen.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/LanScannerScreen.kt))
+- Developed a new Material 3 Compose screen featuring:
+  - A **Network State Card** showing the current connected network and CIDR.
+  - **Editable IP Range inputs** allowing users to define a custom Start IP and End IP to scan.
+  - **Quick Scan** (checks common IPs like `.1`, `.100`, `.254`) and **Full Scan** (sweeps the specified range).
+  - A real-time **Progress Indicator** and device counter.
+  - A scrollable **LazyColumn** displaying each discovered device with its IP, Hostname, MAC address, and latency.
+  - A **History Section** that displays past scans.
+
+### 4. Integration ([MainActivity.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/MainActivity.kt) & [AndroidManifest.xml](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/AndroidManifest.xml))
+- Added the [LanScanner](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/LanScannerScreen.kt#59-132) route and embedded it into the app's primary `NavigationBar`.
+- Added the `<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />` permission required for scanning the local subnet.
+
+## Validation Results
+- The app successfully compiles via `./gradlew assembleDebug` with 0 errors.
+- The UI navigation displays the new "LAN Scan" icon in the bottom menu alongside Ping, Traceroute, etc.
+
+## How to Test
+1. Build and install the app on your Android device connected to a WiFi network.
+2. Tap the **LAN Scan** tab on the bottom bar.
+3. Observe your current network CIDR at the top (e.g., `192.168.1.0/24`).
+4. Press **Quick Scan** and watch the router (`.1`) and typical devices appear.
+5. Press **Full Scan** to sweep all ~254 potential hosts. The progress bar will indicate real-time status.
+6. Verify that stopping a scan midway records a partial history entry at the bottom of the screen.

--- a/notes/new-feature_time2.google.com
+++ b/notes/new-feature_time2.google.com
@@ -1,0 +1,129 @@
+# Add "Google Time Sync" Feature
+
+## Objective
+Add a new feature that queries Google's time sync endpoint `http://clients2.google.com/time/1/current` and displays synchronized time with offset calculation.
+
+## Endpoint Specification
+```
+GET http://clients2.google.com/time/1/current
+```
+
+### Response Handling
+1. Response is prefixed with `)]}'` (XSSI protection) → **strip first 4 characters** before parsing
+2. JSON schema:
+```json
+{
+  "current_time_millis": 1776240093024,  // int64, UTC epoch ms
+  "server_nonce": -6.984715536726945E9    // double, replay-attack nonce
+}
+```
+
+### Time Sync Calculation Logic
+```
+T1 = client timestamp (ms) just BEFORE sending request
+T4 = client timestamp (ms) when response is RECEIVED
+serverTime = current_time_millis from response
+
+RTT = T4 - T1
+correctedServerTime = serverTime + (RTT / 2)
+offset = correctedServerTime - T4  // positive = local clock behind
+```
+
+## 🏗️ Implementation Requirements
+
+### 1. Network Layer
+- Create `GoogleTimeSyncRepository` with suspend function `fetchGoogleTime(host: String = "clients2.google.com")`
+- Use `HttpURLConnection` or `Ktor Client` (lightweight, no new heavy deps)
+- Handle:
+  - Stripping `)]}'` prefix
+  - JSON parsing via `kotlinx.serialization` or `org.json`
+  - Timeout: 10s connection, 15s read
+  - IOException, malformed response, non-200 status
+
+### 2. Domain/Use Case
+- Create `CalculateTimeOffsetUseCase`:
+```kotlin
+data class TimeSyncResult(
+    val serverTimeMillis: Long,
+    val rttMillis: Long,
+    val offsetMillis: Long,      // local = server + offset
+    val correctedServerTimeMillis: Long,
+    val requestTimestamp: Long,  // T1
+    val responseTimestamp: Long  // T4
+)
+```
+
+### 3. ViewModel (`GoogleTimeSyncViewModel`)
+- StateFlow UI state: `Idle`, `Loading`, `Success(TimeSyncResult)`, `Error(String)`
+- Expose: `fun syncTime(host: String)`, `fun reset()`
+- Keep last result in memory for UI re-composition
+
+### 4. UI Screen (`GoogleTimeSyncScreen.kt`)
+- Input field for host (default: `clients2.google.com`) with "Sync" button
+- Loading indicator during request
+- Result card showing:
+  - 🕐 Server time (formatted: `yyyy-MM-dd HH:mm:ss.SSS UTC`)
+  - 📡 RTT: `XXX ms`
+  - ⏱️ Offset: `+XX ms` / `-XX ms` (color-coded: green=small, orange=medium, red=large)
+  - 🧮 Corrected local time preview
+- "Copy offset" button for manual clock adjustment
+- Error snackbar with retry option
+- Follow Material 3 guidelines, support dark mode
+
+### 5. Navigation & Integration
+- Add new route `google_time_sync` in `NavGraph`
+- Add entry in main toolbox screen (icon: `Icons.Default.AccessTime`)
+- Add string resources in `strings.xml` (prepare for localization)
+
+### 6. Permissions & Manifest
+- Ensure `<uses-permission android:name="android.permission.INTERNET" />` is declared
+- Add `android:usesCleartextTraffic="true"` in `<application>` (endpoint is HTTP)
+
+### 7. Testing & Edge Cases
+- Handle: no network, timeout, invalid JSON, missing prefix, non-200 response
+- Unit test `CalculateTimeOffsetUseCase` with mock T1/T4/serverTime
+- UI test: loading → success flow
+
+## 🎨 UI Copy (English, adapt for FR if needed)
+- Title: "Google Time Sync"
+- Subtitle: "Query clients2.google.com for UTC time with offset calculation"
+- Button: "Sync Now"
+- Labels: "Server Time", "Round-Trip Time", "Clock Offset", "Corrected Time"
+- Helper: "Offset = corrected server time − your device time"
+
+## ✅ Acceptance Criteria
+- [ ] App queries endpoint over HTTP and parses response correctly
+- [ ] Time calculations match specification (RTT/offset/corrected time)
+- [ ] UI shows loading, success, and error states
+- [ ] Works on Min SDK 26, no crashes on rotation/config change
+- [ ] Follows existing code style and architecture patterns
+- [ ] No new heavy dependencies added
+
+## 📁 Suggested File Structure
+```
+app/
+├── src/main/java/com/yourapp/timesync/
+│   ├── data/
+│   │   ├── GoogleTimeSyncRepository.kt
+│   │   └── model/GoogleTimeResponse.kt
+│   ├── domain/
+│   │   └── CalculateTimeOffsetUseCase.kt
+│   ├── presentation/
+│   │   ├── GoogleTimeSyncViewModel.kt
+│   │   ├── GoogleTimeSyncScreen.kt
+│   │   └── model/TimeSyncUiState.kt
+│   └── navigation/GoogleTimeSyncNavGraph.kt
+├── src/main/res/values/strings.xml (add new string resources)
+└── AndroidManifest.xml (verify cleartext traffic permission)
+```
+
+## 💡 Pro Tips
+- Use `System.currentTimeMillis()` for T1/T4 (sufficient precision for ms-level sync)
+- Consider adding a "last synced" timestamp in UI
+- For advanced: allow user to apply offset to display a "synced clock" preview
+- Log verbose network events only in debug builds
+```
+
+---
+
+> ℹ️ **Note for you**: Since your endpoint uses **HTTP (not HTTPS)**, remember that `android:usesCleartextTraffic="true"` is required in `AndroidManifest.xml`. For production, consider warning users about cleartext traffic in a tooltip.


### PR DESCRIPTION
The LAN Scanner feature has been successfully implemented and integrated into the `NTP DIG PING MORE` app!

## Changes Made

### 1. Data Layer ([LanScannerRepository.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/LanScannerRepository.kt) & [LanScannerHistoryStore.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/LanScannerHistoryStore.kt))
- Added network utilities to detect the active WiFi/Ethernet connection, calculating the subnet mask, base IP, and CIDR.
- Implemented [ping()](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/LanScannerRepository.kt#75-102) using the native native `ping -c 1 -W 1` command to quickly check if a host is alive, extracting the latency in `ms`.
- Added reverse DNS lookup functionality to display the hostname if available.
- Added ARP table reading from `/proc/net/arp` to fetch the true MAC address of discovered devices.
- Integrated [LanScannerHistoryStore](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/LanScannerHistoryStore.kt#23-68) using Jetpack DataStore to persist recent scan metadata.

### 2. Presentation Layer ([LanScannerViewModel.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/LanScannerViewModel.kt))
- Created a Coroutine-powered ViewModel that chunks IP scanning into batches to ensure the UI remains responsive and the network isn't flooded.
- Tracks `progress` from 0.0 to 1.0, updating the UI whenever an IP check finishes.
- Identifies the gateway (usually `.1`) and highlights it as a "Router" vs a regular "Device".
- Safely cancels in-flight Coroutines if the user presses "Stop Scan" or navigates away.

### 3. UI Layer ([LanScannerScreen.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/LanScannerScreen.kt))
- Developed a new Material 3 Compose screen featuring:
  - A **Network State Card** showing the current connected network and CIDR.
  - **Editable IP Range inputs** allowing users to define a custom Start IP and End IP to scan.
  - **Quick Scan** (checks common IPs like `.1`, `.100`, `.254`) and **Full Scan** (sweeps the specified range).
  - A real-time **Progress Indicator** and device counter.
  - A scrollable **LazyColumn** displaying each discovered device with its IP, Hostname, MAC address, and latency.
  - A **History Section** that displays past scans.

### 4. Integration ([MainActivity.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/MainActivity.kt) & [AndroidManifest.xml](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/AndroidManifest.xml))
- Added the [LanScanner](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/LanScannerScreen.kt#59-132) route and embedded it into the app's primary `NavigationBar`.
- Added the `<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />` permission required for scanning the local subnet.

## Validation Results
- The app successfully compiles via `./gradlew assembleDebug` with 0 errors.
- The UI navigation displays the new "LAN Scan" icon in the bottom menu alongside Ping, Traceroute, etc.

## How to Test
1. Build and install the app on your Android device connected to a WiFi network.
2. Tap the **LAN Scan** tab on the bottom bar.
3. Observe your current network CIDR at the top (e.g., `192.168.1.0/24`).
4. Press **Quick Scan** and watch the router (`.1`) and typical devices appear.
5. Press **Full Scan** to sweep all ~254 potential hosts. The progress bar will indicate real-time status.
6. Verify that stopping a scan midway records a partial history entry at the bottom of the screen.