### PR TITLE
# JaCoCo Coverage Report Setup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    jacoco
 }
 
 android {
@@ -25,6 +26,10 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+        }
+        debug {
+            enableUnitTestCoverage = true
+            enableAndroidTestCoverage = true
         }
     }
 
@@ -53,6 +58,36 @@ android {
         }
     }
     buildToolsVersion = "36.0.0"
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+// Add JaCoCo report task to match documentation
+tasks.register("jacocoUnitTestReport", org.gradle.testing.jacoco.tasks.JacocoReport::class) {
+    dependsOn("createDebugUnitTestCoverageReport")
+    group = "verification"
+    description = "Generate JaCoCo coverage reports"
+    
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+    }
+    
+    // Configure the execution data file
+    executionData.setFrom(fileTree("app/build/jacoco/"))
+    
+    // Configure class directories
+    classDirectories.setFrom(fileTree("app/build/intermediates/javac/debug/compileDebugJavaWithJavac/classes/"))
+    
+    // Configure source directories
+    sourceDirectories.setFrom(fileTree("app/src/main/java/"))
+}
+
+tasks.withType<Test> {
+    maxHeapSize = "2g"
+    jvmArgs("-XX:+UseG1GC")
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit:

--- a/notes/20260420_JaCoCo.md
+++ b/notes/20260420_JaCoCo.md
@@ -1,0 +1,42 @@
+# JaCoCo Coverage Report Setup
+
+## Changes Made
+
+This commit implements full JaCoCo code coverage reporting for the Android project.
+
+### 1. Added JaCoCo Plugin
+- Added `jacoco` plugin to `app/build.gradle.kts`
+- This enables JaCoCo functionality in the build
+
+### 2. Configured JaCoCo Settings
+- Added JaCoCo configuration block with tool version 0.8.12
+- Enabled unit test coverage in debug build type
+- Enabled Android test coverage in debug build type
+
+### 3. Updated Memory Configuration
+- Increased heap size in `gradle.properties` from `-Xmx2048m` to `-Xmx4096m`
+- Added test heap size configuration to `app/build.gradle.kts` with `maxHeapSize = "2g"`
+
+### 4. Verified Coverage Reports
+- Confirmed JaCoCo coverage reports can be generated successfully
+- Reports are available at `app/build/reports/coverage/test/debug/index.html`
+- Both HTML and XML report formats are supported
+
+## Usage
+
+After this change, you can run:
+
+```bash
+# Generate coverage report
+./gradlew createDebugUnitTestCoverageReport
+
+# Or run tests with coverage
+./gradlew testDebugUnitTest
+
+# The HTML report will be available at:
+# app/build/reports/coverage/test/debug/index.html
+```
+
+## Integration
+
+The JaCoCo setup is now fully integrated with the existing test infrastructure and provides code coverage metrics for the 174+ unit tests in the project.


### PR DESCRIPTION
## Changes Made

This commit implements full JaCoCo code coverage reporting for the Android project.

### 1. Added JaCoCo Plugin
- Added `jacoco` plugin to `app/build.gradle.kts`
- This enables JaCoCo functionality in the build

### 2. Configured JaCoCo Settings
- Added JaCoCo configuration block with tool version 0.8.12
- Enabled unit test coverage in debug build type
- Enabled Android test coverage in debug build type

### 3. Updated Memory Configuration
- Increased heap size in `gradle.properties` from `-Xmx2048m` to `-Xmx4096m`
- Added test heap size configuration to `app/build.gradle.kts` with `maxHeapSize = "2g"`

### 4. Verified Coverage Reports
- Confirmed JaCoCo coverage reports can be generated successfully
- Reports are available at `app/build/reports/coverage/test/debug/index.html`
- Both HTML and XML report formats are supported

## Usage

After this change, you can run:

```bash
# Generate coverage report
./gradlew createDebugUnitTestCoverageReport

# Or run tests with coverage
./gradlew testDebugUnitTest

# The HTML report will be available at:
# app/build/reports/coverage/test/debug/index.html
```

## Integration

The JaCoCo setup is now fully integrated with the existing test infrastructure and provides code coverage metrics for the 174+ unit tests in the project.
