### PR TITLE
feat: add version handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,6 +30,7 @@ android {
             )
         }
         debug {
+            versionNameSuffix = "-dev"
             enableUnitTestCoverage = true
             enableAndroidTestCoverage = true
         }

--- a/notes/20260421_VersionHandling.md
+++ b/notes/20260421_VersionHandling.md
@@ -1,0 +1,41 @@
+# Version Handling
+
+## Options Considered
+
+### Option 1: `versionNameSuffix` per Build Type
+- Appends a suffix to `versionName` based on the build variant.
+- **Retained.**
+
+### Option 2: Separate `version.properties` File
+- External properties file for version metadata.
+- More flexible but adds file maintenance overhead.
+
+### Option 3: Product Flavors (Multiple Release Channels)
+- Supports parallel release/beta channels (e.g., Google Play stable + beta tracks).
+- More complex, 4 APK variants (debug/release × release/beta).
+
+## Implementation (Option 1 Retained)
+
+```kotlin
+// app/build.gradle.kts
+
+defaultConfig {
+    versionName = "2.3"
+}
+
+buildTypes {
+    debug {
+        versionNameSuffix = "-dev"
+    }
+    release {
+        // no suffix
+    }
+}
+```
+
+## Result
+
+| Variant   | Version Name |
+|-----------|-------------|
+| Debug     | `2.3-dev`   |
+| Release   | `2.3`       |


### PR DESCRIPTION
## Changes

- Appends `-dev` suffix to debug APK version name (e.g., `2.3-dev`)
- Release APK version name remains unchanged (e.g., `2.3`)
- Documented in `notes/20260421_VersionHandling.md` (all options considered)