### PR TITLE
fix: make release signing conditional for CI compatibility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,18 +8,14 @@ plugins {
 }
 
 android {
-    signingConfigs {
-        getByName("debug") {
-            storeFile =
-                file("/Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/.keystore/my-debug.keystore")
-            storePassword = "ASuperAmazingPassword4Keystore$}"
-            keyAlias = "my-debug-key"
-        }
-        create("release") {
-            storeFile =
-                file("/Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/.keystore/my-release.keystore")
-            storePassword = "1PassIs1PassWaitNoMaybe?"
-            keyAlias = "my-release-key"
+    val releaseKeystore = file(".keystore/my-release.keystore")
+    if (releaseKeystore.exists()) {
+        signingConfigs {
+            create("release") {
+                storeFile = releaseKeystore
+                storePassword = "1PassIs1PassWaitNoMaybe?"
+                keyAlias = "my-release-key"
+            }
         }
     }
     namespace = "io.github.mobilutils.ntp_dig_ping_more"
@@ -33,7 +29,6 @@ android {
         versionName = "2.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        signingConfig = signingConfigs.getByName("release")
     }
 
     buildTypes {


### PR DESCRIPTION
## Problem

Release signing config uses a hardcoded local path to the keystore. On CI, the file doesn't exist → build fails:

```
property 'signingConfigData.storeFile' specifies file '.keystore/my-release.keystore' which doesn't exist
```

## Solution

- Make signing config conditional: only applied when keystore file exists
- Remove `signingConfig` from `defaultConfig` (CI handles signing via `r0adkll/sign-android-release`)
- Local Android Studio builds still sign automatically when keystore is present