### PR TITLE
# Bulk Actions Pseudo Commands — Implementation Plan

### DIFF
--- a/QWEN.md
+++ b/QWEN.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-A modern Android app (min SDK 26, target SDK 36) providing **network diagnostics tools**: NTP Check, DNS Lookup (DIG), Ping, Traceroute, Port Scanner, LAN Scanner, Google Time Sync, and Device Info. Built with **Kotlin**, **Jetpack Compose (Material 3)**, **MVVM architecture**, and **Kotlin Coroutines**.
+A modern Android app (min SDK 26, target SDK 36) providing **network diagnostics tools**: NTP Check, DNS Lookup (DIG), Ping, Traceroute, Port Scanner, LAN Scanner, Google Time Sync, Device Info, and **Bulk Actions** (batch execute commands from a JSON config). Built with **Kotlin**, **Jetpack Compose (Material 3)**, **MVVM architecture**, and **Kotlin Coroutines**.
 
 The app is packaged under `io.github.mobilutils.ntp_dig_ping_more` (version 2.4, versionCode 6).
 
@@ -42,6 +42,12 @@ app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/
 ├── HttpsCertViewModel.kt        # HTTPS cert UI state
 ├── HttpsCertRepository.kt       # HTTPS cert I/O
 ├── HttpsCertHistoryStore.kt     # DataStore persistence
+├── BulkActionsRepository.kt     # JSON config parsing, command mapping (9 pseudo-commands), sequential execution
+├── BulkActionsViewModel.kt      # UI state, file loading, run/stop/clear/export
+├── BulkActionsScreen.kt         # File picker, config summary, progress bar, terminal output
+├── BulkActionsHistoryStore.kt   # DataStore persistence of last 5 config URIs
+├── BulkConfigParserTest.kt      # 9 unit tests for parsing logic
+├── BulkActionsViewModelTest.kt  # 5 unit tests for ViewModel state management
 ├── deviceinfo/
 │   ├── DeviceInfoModels.kt      # Data models (DeviceInfo, CertificateInfo)
 │   ├── SystemInfoRepository.kt  # Identity, network, battery, storage, certs
@@ -53,7 +59,41 @@ app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/
     └── Type.kt                  # Typography
 ```
 
-**37 Kotlin source files** total across the main source set.
+**43 Kotlin source files** total across the main source set (includes Bulk Actions).
+
+---
+
+## Bulk Actions
+
+The **Bulk Actions** feature lets users execute multiple diagnostic commands from a JSON config file.
+
+### Supported Pseudo-Commands
+
+| Command | Syntax | Description |
+|---|---|-:--|
+| `ping` | `ping -c N host` | ICMP ping (N packets) |
+| `dig` | `dig @server fqdn` | DNS lookup |
+| `ntp` | `ntp pool` | NTP query |
+| `port-scan` | `port-scan -p ports host` | TCP port scan (renamed from `nmap`) |
+| `checkcert` | `checkcert -p port host` | HTTPS certificate check |
+| `device-info` | `device-info` | Device identity, network, battery, storage |
+| `tracert` | `tracert <host>` | TTL-probing traceroute |
+| `google-timesync` | `google-timesync` | Google time sync (server time, RTT, offset) |
+| `lan-scan` | `lan-scan` | LAN subnet device discovery |
+
+**Breaking change:** `nmap` prefix is no longer recognized. Use `port-scan` instead.
+
+### Architecture
+
+- `BulkConfigParser` — Pure JSON parsing (no Android API dependencies in JVM tests)
+- `BulkActionsRepository` — Command mapping, sequential execution with 30s timeout per command, Context-injected for `SystemInfoRepository`, `GoogleTimeSyncRepository`, `LanScannerRepository`
+- `BulkActionsViewModel` — UI state (`BulkUiState`), file loading, run/stop/clear/export
+- `BulkActionsHistoryStore` — DataStore persistence of last 5 config URIs
+- Example configs in `notes/config-files_bulk-actions/`
+
+### Traceroute Note
+
+Traceroute uses `ping -c 1 -t <TTL>` which requires `CAP_NET_RAW` (root or specific capabilities). On non-rooted Android devices, TTL probes may always show `* * *` — this is expected behavior.
 
 ---
 
@@ -226,6 +266,7 @@ All tools use sealed result classes to represent success/failure states:
 4. **LAN Scanner**: Uses concurrent ping/ARP sweep for device discovery.
 5. **Android 10+ restrictions**: IMEI, serial number, and other sensitive APIs are restricted; clear fallback messages are shown.
 6. **`android.builtInKotlin=false`** and other AGP 9.0 compatibility flags are set in `gradle.properties`.
+7. **Bulk Actions Context injection**: `BulkActionsRepository` requires `Context` (for `SystemInfoRepository`, `LanScannerRepository`). Always pass `context.applicationContext` from the ViewModel factory to avoid memory leaks.
 
 ## Qwen Added Memories
 - Project: android-ntp_dig_ping_more Android app (Kotlin, Compose, MVVM). Test fixing progress: 31 failures → 8 failures. Fixed: HttpsCertViewModelTest (7 tests via explicit result stubs), LanScannerViewModelTest initial state assertion, TracerouteViewModel history cap, DeviceInfoViewModel stopPeriodicUpdates. Remaining 8 failures: DigViewModelTest (1), LanScannerViewModelTest (history saved, activeDevices), DeviceInfoViewModelTest (4 periodic update/permission tests). Source changes: LanScannerViewModel.kt +.take(10) cap, TracerouteViewModel.kt +.take(5) cap, DeviceInfoViewModel.kt +stopPeriodicUpdates().

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ connect.hostinger.com.   120  IN  A      34.120.137.41
 
 ### ⚡ Bulk Actions
 - Load a JSON configuration file defining multiple diagnostic commands to execute in sequence
-- Supports built-in command types: `ping`, `dig`, `ntp`, `nmap` (port scan), `checkcert` (HTTPS certificate)
+- Supports built-in command types: `ping`, `dig`, `ntp`, `port-scan`, `checkcert`, `device-info`, `tracert`, `google-timesync`, `lan-scan`
 - Unknown command prefixes fall back to raw shell execution
 - Each command runs with a 30-second timeout; failures and timeouts are captured per-command without stopping the batch
 - Real-time progress bar with command-by-command status (SUCCESS / ERROR / TIMEOUT)

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
@@ -1,6 +1,8 @@
 package io.github.mobilutils.ntp_dig_ping_more
 
+import android.content.Context
 import android.os.Environment
+import io.github.mobilutils.ntp_dig_ping_more.deviceinfo.SystemInfoRepository
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -180,6 +182,7 @@ object BulkConfigParser {
  * @return            List of [BulkCommandResult] in command order.
  */
 class BulkActionsRepository(
+    private val context: Context,
     private val digRepo: DigRepository = DigRepository(),
     private val ntpRepo: NtpRepository = NtpRepository(),
     private val certRepo: HttpsCertRepository = HttpsCertRepository(),
@@ -221,12 +224,16 @@ class BulkActionsRepository(
         val prefix = parts.firstOrNull()?.lowercase() ?: ""
 
         return when {
-            prefix == "ping" -> executePing(name, trimmed, parts)
-            prefix == "dig"  -> executeDig(name, trimmed)
-            prefix == "ntp"  -> executeNtp(name, trimmed)
-            prefix == "nmap" -> executeNmap(name, trimmed)
-            prefix == "checkcert" -> executeCheckcert(name, trimmed)
-            else             -> executeRaw(name, trimmed)
+            prefix == "ping"            -> executePing(name, trimmed, parts)
+            prefix == "dig"             -> executeDig(name, trimmed)
+            prefix == "ntp"             -> executeNtp(name, trimmed)
+            prefix == "port-scan"       -> executePortScan(name, trimmed)
+            prefix == "checkcert"       -> executeCheckcert(name, trimmed)
+            prefix == "device-info"     -> executeDeviceInfo(name, trimmed)
+            prefix == "tracert"         -> executeTracert(name, trimmed)
+            prefix == "google-timesync" -> executeGoogleTimeSync(name, trimmed)
+            prefix == "lan-scan"        -> executeLanScan(name, trimmed)
+            else                        -> executeRaw(name, trimmed)
         }
     }
 
@@ -335,9 +342,9 @@ class BulkActionsRepository(
         }
     }
 
-    // ── nmap (port scan) ────────────────────────────────────────────────
+    // ── port-scan (formerly nmap) ────────────────────────────────────────────────
 
-    private suspend fun executeNmap(name: String, cmd: String): BulkCommandResult {
+    private suspend fun executePortScan(name: String, cmd: String): BulkCommandResult {
         return withContext(Dispatchers.IO) {
             try {
                 val t0 = System.currentTimeMillis()
@@ -425,6 +432,206 @@ class BulkActionsRepository(
                     }
                 }
                 BulkCommandSuccess(name, cmd, lines, duration)
+            } catch (e: Exception) {
+                BulkCommandError(name, cmd, e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    // ── device-info ─────────────────────────────────────────────────────
+
+    private suspend fun executeDeviceInfo(name: String, cmd: String): BulkCommandResult {
+        return withContext(Dispatchers.IO) {
+            try {
+                val t0 = System.currentTimeMillis()
+                val repo = SystemInfoRepository(context)
+                val di = repo.getDeviceInfo()
+                val dur = System.currentTimeMillis() - t0
+
+                val lines = buildList {
+                    add("[${timestampFmt.format(LocalDateTime.now())}] $cmd")
+                    add("[${timestampFmt.format(LocalDateTime.now())}] Status: SUCCESS (${dur}ms)")
+                    add("  Device Name: ${di.deviceName}")
+                    add("  Android Version: ${di.androidVersion}")
+                    add("  API Level: ${di.apiLevel}")
+                    add("  IPv4: ${di.ipv4Address ?: "N/A"}")
+                    add("  IPv6: ${di.ipv6Address ?: "N/A"}")
+                    add("  Subnet Mask: ${di.subnetMask ?: "N/A"}")
+                    add("  Default Gateway: ${di.defaultGateway ?: "N/A"}")
+                    add("  NTP Server: ${di.ntpServer ?: "N/A"}")
+                    add("  DNS Servers: ${di.dnsServers?.joinToString(", ") ?: "N/A"}")
+                    add("  Carrier: ${di.carrierName ?: "N/A"}")
+                    add("  Wi-Fi SSID: ${di.wifiSSID ?: "N/A"}")
+                    add("  Battery Level: ${di.batteryLevel ?: "N/A"}%")
+                    add("  Charging: ${di.isCharging ?: "N/A"}")
+                    add("  Battery Health: ${di.batteryHealth ?: "N/A"}")
+                    add("  Time Since Reboot: ${di.timeSinceReboot}")
+                    add("  IMEI: ${di.imei ?: "Restricted by Android 10+"}")
+                    add("  Serial: ${di.serialNumber ?: "Restricted by Android 10+"}")
+                    add("  ICCID: ${di.iccid ?: "Restricted by Android 10+"}")
+                    add("  Total RAM: ${di.totalRam ?: "N/A"}")
+                    add("  Available RAM: ${di.availableRam ?: "N/A"}")
+                    add("  Total Storage: ${di.totalStorage ?: "N/A"}")
+                    add("  Available Storage: ${di.availableStorage ?: "N/A"}")
+                    add("  CPU ABI: ${di.cpuAbi?.joinToString(", ") ?: "N/A"}")
+                    add("  Active Network: ${di.activeNetworkType ?: "N/A"}")
+                }
+                BulkCommandSuccess(name, cmd, lines, dur)
+            } catch (e: Exception) {
+                BulkCommandError(name, cmd, e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    // ── tracert ─────────────────────────────────────────────────────────
+
+    private suspend fun executeTracert(name: String, cmd: String): BulkCommandResult {
+        return withContext(Dispatchers.IO) {
+            try {
+                val parts = cmd.split(Regex("\\s+"))
+                val host = parts.getOrNull(1)
+                    ?: return@withContext BulkCommandError(name, cmd, "Usage: tracert <host>")
+
+                val t0 = System.currentTimeMillis()
+                val out = mutableListOf<String>()
+                var dstReached = false
+                var hops = 0
+
+                out.add("[${timestampFmt.format(LocalDateTime.now())}] $cmd")
+                out.add("traceroute to $host, 30 hops max")
+
+                val ttlIpRegex = Regex("""From (\S+).*[Tt]ime to live exceeded""")
+                val dstReplyRegex = Regex("""bytes from (\S+):""")
+                val ttlAltRegex = Regex("""From (\S+):.*ttl""", RegexOption.IGNORE_CASE)
+
+                for (ttl in 1..30) {
+                    val num = ttl.toString().padStart(2)
+                    try {
+                        val proc = Runtime.getRuntime().exec(
+                            arrayOf("ping", "-c", "1", "-t", ttl.toString(), "-W", "2", host)
+                        )
+                        val stdout = proc.inputStream.bufferedReader().readText()
+                        val stderr = proc.errorStream.bufferedReader().readText()
+                        proc.waitFor()
+                        val elapsed = System.currentTimeMillis() - t0
+                        val combined = stdout + "\n" + stderr
+
+                        when {
+                            ttlIpRegex.containsMatchIn(combined) -> {
+                                val ip = ttlIpRegex.find(combined)!!.groupValues[1].trimEnd(':')
+                                out.add("$num  $ip  ${elapsed} ms")
+                                hops++
+                            }
+                            dstReplyRegex.containsMatchIn(combined) -> {
+                                val ip = dstReplyRegex.find(combined)!!.groupValues[1].trimEnd(':')
+                                val rtt = Regex("""time[=<]([\d.]+) ms""").find(combined)
+                                    ?.groupValues?.get(1)?.let { "$it ms" } ?: "${elapsed} ms"
+                                out.add("$num  $ip  $rtt")
+                                hops++
+                                dstReached = true
+                                break
+                            }
+                            ttlAltRegex.containsMatchIn(combined) -> {
+                                val ip = ttlAltRegex.find(combined)!!.groupValues[1].trimEnd(':')
+                                out.add("$num  $ip  ${elapsed} ms")
+                                hops++
+                            }
+                            else -> out.add("$num  * * *")
+                        }
+                    } catch (_: Exception) {
+                        out.add("$num  * * *")
+                    }
+                }
+
+                val dur = System.currentTimeMillis() - t0
+                out.add("[${timestampFmt.format(LocalDateTime.now())}] Status: COMPLETE (${dur}ms)")
+                out.add("  Reachable hops: $hops, Destination reached: $dstReached")
+                BulkCommandSuccess(name, cmd, out, dur)
+            } catch (e: Exception) {
+                BulkCommandError(name, cmd, e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    // ── google-timesync ─────────────────────────────────────────────────
+
+    private suspend fun executeGoogleTimeSync(name: String, cmd: String): BulkCommandResult {
+        return withContext(Dispatchers.IO) {
+            try {
+                val t0 = System.currentTimeMillis()
+                val repo = GoogleTimeSyncRepository()
+                val result = repo.fetchGoogleTime()
+                val dur = System.currentTimeMillis() - t0
+
+                val lines = buildList {
+                    add("[${timestampFmt.format(LocalDateTime.now())}] $cmd")
+                    when (result) {
+                        is GoogleTimeSyncResult.Success -> {
+                            add("[${timestampFmt.format(LocalDateTime.now())}] Status: SUCCESS (${dur}ms)")
+                            add("  Server Time:  ${java.util.Date(result.data.serverTimeMillis)}")
+                            add("  RTT:          ${result.data.rttMillis} ms")
+                            add("  Offset:       ${result.data.offsetMillis} ms")
+                            add("  Corrected:    ${java.util.Date(result.data.correctedServerTimeMillis)}")
+                        }
+                        is GoogleTimeSyncResult.NoNetwork ->
+                            add("[${timestampFmt.format(LocalDateTime.now())}] Status: NO NETWORK (${dur}ms)")
+                        is GoogleTimeSyncResult.Timeout ->
+                            add("[${timestampFmt.format(LocalDateTime.now())}] Status: TIMEOUT (${dur}ms)")
+                        is GoogleTimeSyncResult.HttpError ->
+                            add("[${timestampFmt.format(LocalDateTime.now())}] Status: HTTP ${result.code} (${dur}ms)")
+                        is GoogleTimeSyncResult.ParseError ->
+                            add("[${timestampFmt.format(LocalDateTime.now())}] Status: PARSE ERROR - ${result.message} (${dur}ms)")
+                        is GoogleTimeSyncResult.Error ->
+                            add("[${timestampFmt.format(LocalDateTime.now())}] Status: ERROR - ${result.message} (${dur}ms)")
+                    }
+                }
+                BulkCommandSuccess(name, cmd, lines, dur)
+            } catch (e: Exception) {
+                BulkCommandError(name, cmd, e.message ?: "Unknown error")
+            }
+        }
+    }
+
+    // ── lan-scan ────────────────────────────────────────────────────────
+
+    private suspend fun executeLanScan(name: String, cmd: String): BulkCommandResult {
+        return withContext(Dispatchers.IO) {
+            try {
+                val t0 = System.currentTimeMillis()
+                val repo = LanScannerRepository(context)
+                val subnet = repo.getLocalSubnetInfo()
+                    ?: return@withContext BulkCommandError(name, cmd, "No active WiFi network found")
+
+                val out = mutableListOf<String>()
+                out.add("[${timestampFmt.format(LocalDateTime.now())}] $cmd")
+                out.add("[${timestampFmt.format(LocalDateTime.now())}] Subnet: ${subnet.cidr}")
+                out.add("[${timestampFmt.format(LocalDateTime.now())}] Scanning up to 256 hosts…")
+
+                val devices = mutableListOf<String>()
+                val limit = minOf(subnet.numHosts, 256L).toInt()
+                for (i in 0 until limit) {
+                    val ip = repo.longToIp(subnet.baseIp + i.toLong() + 1)
+                    val rtt = repo.ping(ip)
+                    if (rtt == null) continue
+                    val mac = repo.getMacFromArpTable(ip)
+                    val host = repo.resolveHostname(ip)
+                    val isRouter = (i == 0)
+
+                    val info = buildString {
+                        append(ip)
+                        mac?.let { append(" MAC:$it") }
+                        host?.let { append(" Host:$it") }
+                        append(" RTT:${rtt}ms")
+                        if (isRouter) append(" [ROUTER]")
+                    }
+                    devices.add(info)
+                }
+
+                val dur = System.currentTimeMillis() - t0
+                out.add("[${timestampFmt.format(LocalDateTime.now())}] Status: COMPLETE (${dur}ms)")
+                out.add("  Devices found: ${devices.size}")
+                devices.forEach { out.add("  $it") }
+                BulkCommandSuccess(name, cmd, out, dur)
             } catch (e: Exception) {
                 BulkCommandError(name, cmd, e.message ?: "Unknown error")
             }

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsViewModel.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsViewModel.kt
@@ -43,7 +43,7 @@ data class BulkUiState(
 
 class BulkActionsViewModel(
     private val context: Context,
-    private val repository: BulkActionsRepository = BulkActionsRepository(),
+    private val repository: BulkActionsRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(BulkUiState())
@@ -410,7 +410,7 @@ class BulkActionsViewModel(
                 override fun <T : ViewModel> create(modelClass: Class<T>): T =
                     BulkActionsViewModel(
                         context = context.applicationContext,
-                        repository = BulkActionsRepository(),
+                        repository = BulkActionsRepository(context.applicationContext),
                     ) as T
             }
     }

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkConfigParserTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkConfigParserTest.kt
@@ -137,7 +137,7 @@ class BulkConfigParserTest {
                     "cmd2": "ping -c 5 10.0.0.1",
                     "cmd3": "dig @1.1.1.1 cybernews.com",
                     "cmd4": "ntp pool.ntp.org",
-                    "cmd5": "nmap -p 80-443 mobilutils.com",
+                    "cmd5": "port-scan -p 80-443 mobilutils.com",
                     "cmd6": "checkcert -p 443 example.com"
                 }
             }

--- a/notes/20260425_BulkActions-viaLocalConfigFile.md
+++ b/notes/20260425_BulkActions-viaLocalConfigFile.md
@@ -40,9 +40,15 @@ Added a **Bulk Actions** screen accessible from the MORE overflow menu. Users se
 | `ping` | `ProcessBuilder("ping", "-c", N, host)` — streams stdout line-by-line |
 | `dig @server fqdn` | `DigRepository.resolve(server, fqdn)` — formatted as dig output |
 | `ntp pool` | `NtpRepository.query(pool)` — formatted as NTP result |
-| `nmap -p ports host` | TCP connect scan per port (parses ranges like `80-443` and comma lists) |
+| `port-scan -p ports host` | TCP connect scan per port (renamed from `nmap`; parses ranges like `80-443` and comma lists) |
 | `checkcert -p port host` | `HttpsCertRepository.fetchCertificate(host, port)` — formatted cert info |
+| `device-info` | `SystemInfoRepository.getDeviceInfo()` — outputs device identity, network, battery, storage |
+| `tracert <host>` | TTL-probing via `ping -c 1 -t <TTL>` — hop-by-hop traceroute |
+| `google-timesync` | `GoogleTimeSyncRepository.fetchGoogleTime()` — server time, RTT, clock offset |
+| `lan-scan` | `LanScannerRepository` subnet sweep — discovers active local devices |
 | Unknown | Raw `ProcessBuilder` execution — falls back to shell |
+
+> **Breaking change:** The `nmap` prefix is no longer recognized. Use `port-scan` instead.
 
 ---
 
@@ -109,9 +115,9 @@ Tests ViewModel state management using MockK:
     "cmd2": "ping -c 5 10.0.0.1",
     "cmd3": "dig @1.1.1.1 cybernews.com",
     "cmd4": "ntp pool.ntp.org",
-    "cmd5": "nmap -p 80-443 mobilutils.com",
-    "cmd6": "nmap -p 80,443,8080 cat.phttp.com",
-    "cmd7": "nmap -p 80 landing.phttp.com",
+    "cmd5": "port-scan -p 80-443 mobilutils.com",
+    "cmd6": "port-scan -p 80,443,8080 cat.phttp.com",
+    "cmd7": "port-scan -p 80 landing.phttp.com",
     "cmd8": "checkcert -p 443 landing.phttp.com",
     "cmd9": "checkcert -p 8443 proxy.phttp.com",
     "cmd10": "ntp fr.pool.ntp.org"

--- a/notes/add-pseudo-commands_implementation-plan_qw3.635B.md
+++ b/notes/add-pseudo-commands_implementation-plan_qw3.635B.md
@@ -1,0 +1,458 @@
+# Bulk Actions Pseudo Commands — Implementation Plan
+
+**Date:** 2026-04-26
+**Author:** Qwen Code (qw3.635B)
+**Status:** Plan ready for implementation
+
+---
+
+## Overview
+
+Add four new pseudo-commands to Bulk Actions and rename `nmap` → `port-scan`:
+
+| # | Command | Syntax | Args | Description |
+|---|---------|--------|------|-------------|
+| 1 | `device-info` | `device-info` | none | Outputs device info (IP, MAC, carrier, battery, storage, etc.) |
+| 2 | `tracert` | `tracert <host>` | host (required) | ICMP TTL-probe traceroute |
+| 3 | `google-timesync` | `google-timesync` | none | Fetches Google time, shows offset / RTT |
+| 4 | `lan-scan` | `lan-scan` | none | Scans local WiFi subnet for devices |
+| 5 | `port-scan` | `port-scan -p <ports> <host>` | ports + host (required) | TCP port scan (renamed from `nmap`) |
+
+**Breaking change:** `nmap` prefix is no longer recognized. Existing configs must use `port-scan`.
+
+---
+
+## Current State (as of 2026-04-26)
+
+### `BulkActionsRepository.kt` (the executor)
+
+```kotlin
+class BulkActionsRepository(
+    private val digRepo: DigRepository = DigRepository(),
+    private val ntpRepo: NtpRepository = NtpRepository(),
+    private val certRepo: HttpsCertRepository = HttpsCertRepository(),
+) {
+    // …
+
+    suspend fun executeSingleCommand(name: String, cmd: String): BulkCommandResult {
+        val trimmed = cmd.trim()
+        val parts = trimmed.split(Regex("\\s+"))
+        val prefix = parts.firstOrNull()?.lowercase() ?: ""
+
+        return when {
+            prefix == "ping"      -> executePing(name, trimmed, parts)
+            prefix == "dig"       -> executeDig(name, trimmed)
+            prefix == "ntp"       -> executeNtp(name, trimmed)
+            prefix == "nmap"      -> executeNmap(name, trimmed)    // ← rename to port-scan
+            prefix == "checkcert" -> executeCheckcert(name, trimmed)
+            else                  -> executeRaw(name, trimmed)
+        }
+    }
+}
+```
+
+**Existing infrastructure we can reuse:**
+| New Command | Reuse |
+|---|---|
+| `device-info` | `SystemInfoRepository(context)` — `getDeviceInfo()` returns `DeviceInfo` |
+| `tracert` | Inline `ping -c 1 -t <TTL> -W 2 <host>` (same logic as `TracerouteScreen`) |
+| `google-timesync` | `GoogleTimeSyncRepository()` — `fetchGoogleTime()` returns `GoogleTimeSyncResult` |
+| `lan-scan` | `LanScannerRepository(context)` — `getLocalSubnetInfo()`, `ping()`, `getMacFromArpTable()`, `resolveHostname()` |
+| `port-scan` | Rename `executeNmap` → `executePortScan` (identical Socket logic) |
+
+### `BulkActionsViewModel.kt` (the UI controller)
+
+- Constructor already takes `Context`: `BulkActionsViewModel(context, repository)`
+- Factory creates `BulkActionsRepository()` **without** passing `Context` — this is the bug we fix.
+- `BulkActionsScreen.kt` calls `viewModel(factory = BulkActionsViewModel.factory(context))` — factory already receives context.
+
+### `BulkConfigParserTest.kt` (tests)
+
+- Test `parseMultipleCommandsPreservesAllCommands` contains `"cmd5": "nmap -p 80-443 mobilutils.com"` — update to `port-scan`.
+
+---
+
+## Changes Required
+
+### 1. `BulkActionsRepository.kt` — Major changes
+
+#### A. Add `Context` to constructor
+
+```kotlin
+class BulkActionsRepository(
+    private val context: Context,
+    private val digRepo: DigRepository = DigRepository(),
+    private val ntpRepo: NtpRepository = NtpRepository(),
+    private val certRepo: HttpsCertRepository = HttpsCertRepository(),
+)
+```
+
+#### B. Update the `when` block in `executeSingleCommand()`
+
+```kotlin
+return when {
+    prefix == "ping"            -> executePing(name, trimmed, parts)
+    prefix == "dig"             -> executeDig(name, trimmed)
+    prefix == "ntp"             -> executeNtp(name, trimmed)
+    prefix == "port-scan"       -> executePortScan(name, trimmed)     // renamed
+    prefix == "checkcert"       -> executeCheckcert(name, trimmed)
+    prefix == "device-info"     -> executeDeviceInfo(name, trimmed)   // NEW
+    prefix == "tracert"         -> executeTracert(name, trimmed)      // NEW
+    prefix == "google-timesync" -> executeGoogleTimeSync(name, trimmed) // NEW
+    prefix == "lan-scan"        -> executeLanScan(name, trimmed)      // NEW
+    else                        -> executeRaw(name, trimmed)
+}
+```
+
+#### C. Rename `executeNmap` → `executePortScan`
+
+Copy the body verbatim, update the doc comment and the method name. No logic changes.
+
+#### D. Implement `executeDeviceInfo(name, cmd)`
+
+```kotlin
+private suspend fun executeDeviceInfo(name: String, cmd: String): BulkCommandResult {
+    return withContext(Dispatchers.IO) {
+        try {
+            val t0 = System.currentTimeMillis()
+            val repo = SystemInfoRepository(context)
+            val di = repo.getDeviceInfo()
+            val dur = System.currentTimeMillis() - t0
+
+            val lines = buildList {
+                add("[${timestampFmt(LocalDateTime.now())}] $cmd")
+                add("[${timestampFmt(LocalDateTime.now())}] Status: SUCCESS (${dur}ms)")
+                add("  Device Name: ${di.deviceName}")
+                add("  Android Version: ${di.androidVersion}")
+                add("  API Level: ${di.apiLevel}")
+                add("  IPv4: ${di.ipv4Address ?: "N/A"}")
+                add("  IPv6: ${di.ipv6Address ?: "N/A"}")
+                add("  Subnet Mask: ${di.subnetMask ?: "N/A"}")
+                add("  Default Gateway: ${di.defaultGateway ?: "N/A"}")
+                add("  NTP Server: ${di.ntpServer ?: "N/A"}")
+                add("  DNS Servers: ${di.dnsServers?.joinToString(", ") ?: "N/A"}")
+                add("  Carrier: ${di.carrierName ?: "N/A"}")
+                add("  Wi-Fi SSID: ${di.wifiSSID ?: "N/A"}")
+                add("  Battery Level: ${di.batteryLevel ?: "N/A"}%")
+                add("  Charging: ${di.isCharging ?: "N/A"}")
+                add("  Battery Health: ${di.batteryHealth ?: "N/A"}")
+                add("  Time Since Reboot: ${di.timeSinceReboot}")
+                add("  IMEI: ${di.imei ?: "Restricted by Android 10+"}")
+                add("  Serial: ${di.serialNumber ?: "Restricted by Android 10+"}")
+                add("  ICCID: ${di.iccid ?: "Restricted by Android 10+"}")
+                add("  Total RAM: ${di.totalRam ?: "N/A"}")
+                add("  Available RAM: ${di.availableRam ?: "N/A"}")
+                add("  Total Storage: ${di.totalStorage ?: "N/A"}")
+                add("  Available Storage: ${di.availableStorage ?: "N/A"}")
+                add("  CPU ABI: ${di.cpuAbi?.joinToString(", ") ?: "N/A"}")
+                add("  Active Network: ${di.activeNetworkType ?: "N/A"}")
+            }
+            BulkCommandSuccess(name, cmd, lines, dur)
+        } catch (e: Exception) {
+            BulkCommandError(name, cmd, e.message ?: "Unknown error")
+        }
+    }
+}
+```
+
+#### E. Implement `executeTracert(name, cmd)`
+
+Inline TTL-probing logic (same as `TracerouteScreen`):
+
+```kotlin
+private suspend fun executeTracert(name: String, cmd: String): BulkCommandResult {
+    return withContext(Dispatchers.IO) {
+        try {
+            val parts = cmd.split(Regex("\\s+"))
+            val host = parts.getOrNull(1)
+                ?: return@withContext BulkCommandError(name, cmd, "Usage: tracert <host>")
+
+            val t0 = System.currentTimeMillis()
+            val out = mutableListOf<String>()
+            var dstReached = false
+            var hops = 0
+
+            out.add("[${timestampFmt(LocalDateTime.now())}] $cmd")
+            out.add("traceroute to $host, 30 hops max")
+
+            val ttlIpRegex = Regex("""From (\S+).*[Tt]ime to live exceeded""")
+            val dstReplyRegex = Regex("""bytes from (\S+):""")
+            val ttlAltRegex = Regex("""From (\S+):.*ttl""", RegexOption.IGNORE_CASE)
+
+            for (ttl in 1..30) {
+                val num = ttl.toString().padStart(2)
+                try {
+                    val proc = Runtime.getRuntime().exec(
+                        arrayOf("ping", "-c", "1", "-t", ttl.toString(), "-W", "2", host)
+                    )
+                    val stdout = proc.inputStream.bufferedReader().readText()
+                    val stderr = proc.errorStream.bufferedReader().readText()
+                    proc.waitFor()
+                    val elapsed = System.currentTimeMillis() - t0
+                    val combined = stdout + "\n" + stderr
+
+                    when {
+                        ttlIpRegex.containsMatchIn(combined) -> {
+                            val ip = ttlIpRegex.find(combined)!!.groupValues[1].trimEnd(':')
+                            out.add("$num  $ip  ${elapsed} ms")
+                            hops++
+                        }
+                        dstReplyRegex.containsMatchIn(combined) -> {
+                            val ip = dstReplyRegex.find(combined)!!.groupValues[1].trimEnd(':')
+                            val rtt = Regex("""time[=<]([\d.]+) ms""").find(combined)
+                                ?.groupValues?.get(1)?.let { "$it ms" } ?: "${elapsed} ms"
+                            out.add("$num  $ip  $rtt")
+                            hops++
+                            dstReached = true
+                            break
+                        }
+                        ttlAltRegex.containsMatchIn(combined) -> {
+                            val ip = ttlAltRegex.find(combined)!!.groupValues[1].trimEnd(':')
+                            out.add("$num  $ip  ${elapsed} ms")
+                            hops++
+                        }
+                        else -> out.add("$num  * * *")
+                    }
+                } catch (_: Exception) {
+                    out.add("$num  * * *")
+                }
+            }
+
+            val dur = System.currentTimeMillis() - t0
+            out.add("[${timestampFmt(LocalDateTime.now())}] Status: COMPLETE (${dur}ms)")
+            out.add("  Reachable hops: $hops, Destination reached: $dstReached")
+            BulkCommandSuccess(name, cmd, out, dur)
+        } catch (e: Exception) {
+            BulkCommandError(name, cmd, e.message ?: "Unknown error")
+        }
+    }
+}
+```
+
+#### F. Implement `executeGoogleTimeSync(name, cmd)`
+
+```kotlin
+private suspend fun executeGoogleTimeSync(name: String, cmd: String): BulkCommandResult {
+    return withContext(Dispatchers.IO) {
+        try {
+            val t0 = System.currentTimeMillis()
+            val repo = GoogleTimeSyncRepository()
+            val result = repo.fetchGoogleTime()
+            val dur = System.currentTimeMillis() - t0
+
+            val lines = buildList {
+                add("[${timestampFmt(LocalDateTime.now())}] $cmd")
+                when (result) {
+                    is GoogleTimeSyncResult.Success -> {
+                        add("[${timestampFmt(LocalDateTime.now())}] Status: SUCCESS (${dur}ms)")
+                        add("  Server Time:  ${Date(result.data.serverTimeMillis)}")
+                        add("  RTT:          ${result.data.rttMillis} ms")
+                        add("  Offset:       ${result.data.offsetMillis} ms")
+                        add("  Corrected:    ${Date(result.data.correctedServerTimeMillis)}")
+                    }
+                    is GoogleTimeSyncResult.NoNetwork ->
+                        add("[${timestampFmt(LocalDateTime.now())}] Status: NO NETWORK (${dur}ms)")
+                    is GoogleTimeSyncResult.Timeout ->
+                        add("[${timestampFmt(LocalDateTime.now())}] Status: TIMEOUT (${dur}ms)")
+                    is GoogleTimeSyncResult.HttpError ->
+                        add("[${timestampFmt(LocalDateTime.now())}] Status: HTTP ${result.code} (${dur}ms)")
+                    is GoogleTimeSyncResult.ParseError ->
+                        add("[${timestampFmt(LocalDateTime.now())}] Status: PARSE ERROR - ${result.message} (${dur}ms)")
+                    is GoogleTimeSyncResult.Error ->
+                        add("[${timestampFmt(LocalDateTime.now())}] Status: ERROR - ${result.message} (${dur}ms)")
+                }
+            }
+            BulkCommandSuccess(name, cmd, lines, dur)
+        } catch (e: Exception) {
+            BulkCommandError(name, cmd, e.message ?: "Unknown error")
+        }
+    }
+}
+```
+
+#### G. Implement `executeLanScan(name, cmd)`
+
+```kotlin
+private suspend fun executeLanScan(name: String, cmd: String): BulkCommandResult {
+    return withContext(Dispatchers.IO) {
+        try {
+            val t0 = System.currentTimeMillis()
+            val repo = LanScannerRepository(context)
+            val subnet = repo.getLocalSubnetInfo()
+                ?: return@withContext BulkCommandError(name, cmd, "No active WiFi network found")
+
+            val out = mutableListOf<String>()
+            out.add("[${timestampFmt(LocalDateTime.now())}] $cmd")
+            out.add("[${timestampFmt(LocalDateTime.now())}] Subnet: ${subnet.cidr}")
+            out.add("[${timestampFmt(LocalDateTime.now())}] Scanning up to 256 hosts…")
+
+            val devices = mutableListOf<String>()
+            val limit = minOf(subnet.numHosts, 256L)
+            for (i in 0 until limit) {
+                val ip = repo.longToIp(subnet.baseIp + i + 1)
+                val rtt = repo.ping(ip) ?: continue
+                val mac = repo.getMacFromArpTable(ip)
+                val host = repo.resolveHostname(ip)
+                val isRouter = (i == 0)
+
+                val info = buildString {
+                    append(ip)
+                    mac?.let { append(" MAC:$it") }
+                    host?.let { append(" Host:$it") }
+                    append(" RTT:${rtt}ms")
+                    if (isRouter) append(" [ROUTER]")
+                }
+                devices.add(info)
+            }
+
+            val dur = System.currentTimeMillis() - t0
+            out.add("[${timestampFmt(LocalDateTime.now())}] Status: COMPLETE (${dur}ms)")
+            out.add("  Devices found: ${devices.size}")
+            devices.forEach { out.add("  $it") }
+            BulkCommandSuccess(name, cmd, out, dur)
+        } catch (e: Exception) {
+            BulkCommandError(name, cmd, e.message ?: "Unknown error")
+        }
+    }
+}
+```
+
+---
+
+### 2. `BulkActionsViewModel.kt` — Minor changes
+
+#### A. Update the factory to pass `Context` to repository
+
+```kotlin
+companion object {
+    fun factory(context: Context): ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>): T =
+                BulkActionsViewModel(
+                    context = context.applicationContext,
+                    repository = BulkActionsRepository(context.applicationContext),  // ← pass Context
+                ) as T
+        }
+}
+```
+
+---
+
+### 3. `BulkConfigParserTest.kt` — Minor update
+
+Change the test that references `nmap`:
+
+```kotlin
+// Before:
+"cmd5": "nmap -p 80-443 mobilutils.com"
+
+// After:
+"cmd5": "port-scan -p 80-443 mobilutils.com"
+```
+
+---
+
+### 4. `README.md` — Minor update
+
+Update the Bulk Actions section to list all supported commands:
+
+```markdown
+### ⚡ Bulk Actions
+
+- Supports built-in command types: `ping`, `dig`, `ntp`, `port-scan`, `checkcert`, `device-info`, `tracert`, `google-timesync`, `lan-scan`
+```
+
+---
+
+### 5. `notes/20260425_BulkActions-viaLocalConfigFile.md` — Minor update
+
+Update the command mapping table to include new commands and note the `nmap` → `port-scan` rename.
+
+---
+
+## Example Config File
+
+```json
+{
+  "output-file": "~/Downloads/bulk-output.txt",
+  "run": {
+    "info": "device-info",
+    "trace_google": "tracert google.com",
+    "time_sync": "google-timesync",
+    "local_network": "lan-scan",
+    "port_scan_1": "port-scan -p 80,443 google.com",
+    "port_scan_2": "port-scan -p 22-8080 example.com"
+  }
+}
+```
+
+---
+
+## Test Updates
+
+### New tests to add to `BulkActionsRepositoryTest.kt` (or extend existing)
+
+| Test | What it verifies |
+|---|---|
+| `executeDeviceInfo_success` | Returns `BulkCommandSuccess` with device fields |
+| `executeDeviceInfo_exception` | Returns `BulkCommandError` on repo failure |
+| `executeTracert_success` | Parses TTL hops, detects destination |
+| `executeTracert_missingHost` | Returns error: "Usage: tracert \<host\>" |
+| `executeGoogleTimeSync_success` | Returns server time, RTT, offset |
+| `executeGoogleTimeSync_noNetwork` | Returns `NoNetwork` mapped to error line |
+| `executeLanScan_success` | Returns device list from subnet |
+| `executeLanScan_noNetwork` | Returns error: "No active WiFi network found" |
+| `executePortScan_success` | Parses `-p ports host`, reports open ports |
+| `nmap_noLongerRecognized` | Prefix `nmap` falls through to `executeRaw` |
+
+---
+
+## Permissions Required
+
+All new commands reuse permissions already declared in `AndroidManifest.xml`:
+
+| Permission | Used by |
+|---|---|
+| `INTERNET` | All commands |
+| `ACCESS_NETWORK_STATE` | LAN scan subnet detection |
+| `ACCESS_WIFI_STATE` | LAN scan WiFi detection |
+| `ACCESS_COARSE_LOCATION` / `ACCESS_FINE_LOCATION` | LAN scan SSID |
+| `READ_PHONE_STATE` | Device info IMEI/ICCID (restricted Android 10+) |
+
+---
+
+## Files to Modify
+
+| File | Change | Description |
+|---|---|---|
+| `BulkActionsRepository.kt` | **Major** | Add `Context` param, rename `nmap`→`port-scan`, add 4 executors |
+| `BulkActionsViewModel.kt` | **Minor** | Pass `Context` to `BulkActionsRepository()` in factory |
+| `BulkConfigParserTest.kt` | **Minor** | Update `nmap` reference to `port-scan` |
+| `README.md` | **Minor** | Update command list in Bulk Actions section |
+| `notes/20260425_BulkActions-viaLocalConfigFile.md` | **Minor** | Update command mapping table |
+
+---
+
+## Risk & Edge Cases
+
+1. **Context lifecycle** — `BulkActionsRepository` now holds a `Context`. The ViewModel factory passes `context.applicationContext` to avoid memory leaks.
+
+2. **Traceroute on Android** — Uses `ping -c 1 -t TTL` which requires root or `CAP_NET_RAW`. On non-rooted devices, TTL probes may always fail → output will show `* * *` for each hop. This is expected Android behavior.
+
+3. **LAN scan performance** — Limited to 256 hosts (effectively a /24) to avoid extremely long scans on larger subnets.
+
+4. **Breaking change** — `nmap` prefix no longer works. Any saved config files or user bookmarks referencing `nmap` will fall through to `executeRaw`, which will fail with exit code 127 ("command not found"). Consider adding a deprecation warning in a future release.
+
+---
+
+## Implementation Order (recommended)
+
+1. Rename `executeNmap` → `executePortScan` in `BulkActionsRepository.kt`
+2. Add `Context` parameter to `BulkActionsRepository` constructor
+3. Add the 4 new `when` branches + executor methods to `executeSingleCommand()`
+4. Implement `executeDeviceInfo`, `executeTracert`, `executeGoogleTimeSync`, `executeLanScan`
+5. Update `BulkActionsViewModel.factory()` to pass `Context`
+6. Update `BulkConfigParserTest.kt` (nmap → port-scan)
+7. Update `README.md` and notes files
+8. Add unit tests for new executors

--- a/notes/config-files_bulk-actions/bulk-nmap_one.json
+++ b/notes/config-files_bulk-actions/bulk-nmap_one.json
@@ -1,0 +1,5 @@
+{
+  "run": {
+    "cmd7": "nmap -p 80,89,443-445 landing.phttp.com"
+  }
+}

--- a/notes/config-files_bulk-actions/bulkactions-full-example.json
+++ b/notes/config-files_bulk-actions/bulkactions-full-example.json
@@ -1,0 +1,28 @@
+{
+  "output-file": "~/Downloads/bulk-actions-full-example.txt",
+  "run": {
+    "device_info": "device-info",
+
+    "traceroute_google": "tracert google.com",
+    "traceroute_cloudflare": "tracert 1.1.1.1",
+
+    "google_timesync": "google-timesync",
+
+    "lan_scan": "lan-scan",
+
+    "port_scan_google": "port-scan -p 80,443 google.com",
+    "port_scan_range": "port-scan -p 22-8080 example.com",
+
+    "ping_google": "ping -c 4 google.com",
+    "ping_local": "ping -c 2 10.0.0.1",
+
+    "dig_google_dns": "dig @1.1.1.1 google.com",
+    "dig_cloudflare": "dig @8.8.8.8 example.com",
+
+    "ntp_pool": "ntp pool.ntp.org",
+    "ntp_local": "ntp fr.pool.ntp.org",
+
+    "checkcert_google": "checkcert -p 443 google.com",
+    "checkcert_example": "checkcert -p 443 example.com"
+  }
+}

--- a/notes/config-files_bulk-actions/bulkactions-small-nooutput_SAF.json
+++ b/notes/config-files_bulk-actions/bulkactions-small-nooutput_SAF.json
@@ -5,8 +5,7 @@
   "cmd2": "ping -c 1 10.0.0.1",
   "cmd3": "dig @1.1.1.1 cybernews.com",
   "cmd4": "ntp pool.ntp.org",
-  "cmd6": "nmap -p 80,443,8080 cat.phttp.com",
-  "cmd7": "nmap -p 80 landing.phttp.com",
+  "cmd7": "nmap -p 80,89,443-445 landing.phttp.com",
   "cmd8": "checkcert -p 443 landing.phttp.com",
   "cmd10": "ntp fr.pool.ntp.org"
   }

--- a/notes/config-files_bulk-actions/bulkactions-toocomplexe.json
+++ b/notes/config-files_bulk-actions/bulkactions-toocomplexe.json
@@ -1,0 +1,21 @@
+"cmd7": "nmap -p 80,89,443-445 landing.phttp.com",
+{
+  "output-file": "~/Downloads/output-test-run.txt",
+  "run": [
+    {
+      "cmd": "ping",
+      "arg": {
+      "server": "10.10.10.1",
+      "count": "2"
+    },
+    {
+      "cmd": "nmap",
+      "arg": {
+        "port": ["80", "443", "8080-8081"],
+        "server": "10.0.0.1",
+      }
+    }
+    }
+  ]
+}
+

--- a/notes/portscanner_nmap.md
+++ b/notes/portscanner_nmap.md
@@ -1,0 +1,70 @@
+# Port Scanner Implementation
+
+## Overview
+
+A custom socket-based port scanner that probes TCP and UDP ports on a target host within a user-specified range. **Not nmap** — this app implements its own scanning logic using Java's `Socket` and `DatagramSocket` APIs.
+
+## Architecture
+
+| File | Role |
+|---|---|
+| `PortScannerScreen.kt` | Compose UI: host/port inputs, protocol toggle (TCP/UDP), progress bar, results list, history section |
+| `PortScannerViewModel.kt` | Scanning orchestration, state management via `StateFlow<PortScannerUiState>` |
+| `PortScannerHistoryStore.kt` | DataStore persistence of the last 5 scan configurations |
+
+## How Scanning Works
+
+### TCP Scanning
+For each port in `[startPort, endPort]`, a `java.net.Socket` is created and connected to the target host with a **1-second timeout**. If `connect()` succeeds, the port is reported as open. If any `Exception` is thrown (connection refused, timeout, etc.), the port is considered closed.
+
+### UDP Scanning
+For each port, an empty (`0-byte`) datagram is sent via `DatagramSocket`. The socket waits up to **1 second** for a response. If a packet is received, the port is reported as open. On `SocketTimeoutException` or any other exception, the port is considered closed.
+
+### Concurrency
+Ports are scanned in **chunks of 50** (sequential chunk iteration, concurrent within each chunk). This prevents "too many open files" and OOM errors. Results are collected thread-safely via a `Mutex` and sorted on discovery.
+
+### State Flow
+1. User enters host + port range, selects TCP or UDP
+2. Presses "Scan Ports" → `isRunning = true`, progress resets
+3. Ports are probed in chunks; progress bar and discovered ports update live
+4. On completion → `isRunning = false`, progress = 1.0f, scan saved to history
+
+## History
+- Last 5 scans persisted via DataStore (serialized as newline-delimited pipe-separated fields)
+- History deduplication: if a scan with the same host/port range/protocol is re-run, the entry replaces the oldest duplicate
+- Tapping a history entry populates the form fields and auto-starts a new scan
+
+## Limitations
+
+### UDP scanning is unreliable
+The UDP implementation sends a **zero-byte packet** and waits for any response. This means:
+- **Open ports with no service** → no response → reported as closed (false negative)
+- **Filtered ports** (firewall dropping packets) → timeout → reported as closed (false negative)
+- **Only open ports with an active service** will respond reliably
+
+In short, UDP scanning here is a **best-effort probe**, not a thorough scan. A real UDP scanner (like nmap's) uses service-specific probes with sophisticated timing and classification.
+
+### TCP scanning is also limited
+- **1-second timeout** per port means slow-responding ports may be missed
+- **No port state differentiation** — only "open" vs "closed"; no "filtered", "reset", or "closed-filtered" states
+- **No service detection** — no banner grabbing, no OS fingerprinting
+
+### General limitations vs. nmap
+- No nmap script engine (NSE)
+- No stealth (SYN) scanning
+- No IP protocol scanning
+- No timing/template tuning
+- No MAC address or vendor detection
+
+---
+
+## Possible Improvements in the Future
+
+1. **Add nmap as a dependency or companion CLI tool** — Bundle `nmap-android` (or use the `nmap` CLI via Termux/NDK) for full-featured scanning. This is the most impactful improvement.
+2. **Configurable timeout** — Let users set per-port timeout (currently hardcoded to 1s).
+3. **Well-known port presets** — Add quick-select buttons for common ranges (e.g., "Web Ports 80-443", "Common Services 1-1024").
+4. **Service name lookup** — Use `ServiceManager` or IANA registry to label ports (e.g., "80 → HTTP").
+5. **UDP probe templates** — Add service-specific UDP probes (DNS query, SNMP get, etc.) to improve UDP scan accuracy.
+6. **Parallel scanning with adaptive concurrency** — Dynamically adjust chunk size based on system resources.
+7. **Export results** — Allow saving scan results as CSV or JSON.
+8. **Nmap-compatible output** — If nmap is added, support parsing and displaying its XML output format.


### PR DESCRIPTION
**Date:** 2026-04-26
**Author:** Qwen Code (qw3.635B)
**Status:** Plan ready for implementation

---

## Overview

Add four new pseudo-commands to Bulk Actions and rename `nmap` → `port-scan`:

| # | Command | Syntax | Args | Description |
|---|---------|--------|------|-------------|
| 1 | `device-info` | `device-info` | none | Outputs device info (IP, MAC, carrier, battery, storage, etc.) |
| 2 | `tracert` | `tracert <host>` | host (required) | ICMP TTL-probe traceroute |
| 3 | `google-timesync` | `google-timesync` | none | Fetches Google time, shows offset / RTT |
| 4 | `lan-scan` | `lan-scan` | none | Scans local WiFi subnet for devices |
| 5 | `port-scan` | `port-scan -p <ports> <host>` | ports + host (required) | TCP port scan (renamed from `nmap`) |

**Breaking change:** `nmap` prefix is no longer recognized. Existing configs must use `port-scan`.

---

## Current State (as of 2026-04-26)

### `BulkActionsRepository.kt` (the executor)

```kotlin
class BulkActionsRepository(
    private val digRepo: DigRepository = DigRepository(),
    private val ntpRepo: NtpRepository = NtpRepository(),
    private val certRepo: HttpsCertRepository = HttpsCertRepository(),
) {
    // …

    suspend fun executeSingleCommand(name: String, cmd: String): BulkCommandResult {
        val trimmed = cmd.trim()
        val parts = trimmed.split(Regex("\\s+"))
        val prefix = parts.firstOrNull()?.lowercase() ?: ""

        return when {
            prefix == "ping"      -> executePing(name, trimmed, parts)
            prefix == "dig"       -> executeDig(name, trimmed)
            prefix == "ntp"       -> executeNtp(name, trimmed)
            prefix == "nmap"      -> executeNmap(name, trimmed)    // ← rename to port-scan
            prefix == "checkcert" -> executeCheckcert(name, trimmed)
            else                  -> executeRaw(name, trimmed)
        }
    }
}
```

**Existing infrastructure we can reuse:**
| New Command | Reuse |
|---|---|
| `device-info` | `SystemInfoRepository(context)` — `getDeviceInfo()` returns `DeviceInfo` |
| `tracert` | Inline `ping -c 1 -t <TTL> -W 2 <host>` (same logic as `TracerouteScreen`) |
| `google-timesync` | `GoogleTimeSyncRepository()` — `fetchGoogleTime()` returns `GoogleTimeSyncResult` |
| `lan-scan` | `LanScannerRepository(context)` — `getLocalSubnetInfo()`, `ping()`, `getMacFromArpTable()`, `resolveHostname()` |
| `port-scan` | Rename `executeNmap` → `executePortScan` (identical Socket logic) |

### `BulkActionsViewModel.kt` (the UI controller)

- Constructor already takes `Context`: `BulkActionsViewModel(context, repository)`
- Factory creates `BulkActionsRepository()` **without** passing `Context` — this is the bug we fix.
- `BulkActionsScreen.kt` calls `viewModel(factory = BulkActionsViewModel.factory(context))` — factory already receives context.

### `BulkConfigParserTest.kt` (tests)

- Test `parseMultipleCommandsPreservesAllCommands` contains `"cmd5": "nmap -p 80-443 mobilutils.com"` — update to `port-scan`.

---

## Changes Required

### 1. `BulkActionsRepository.kt` — Major changes

#### A. Add `Context` to constructor

```kotlin
class BulkActionsRepository(
    private val context: Context,
    private val digRepo: DigRepository = DigRepository(),
    private val ntpRepo: NtpRepository = NtpRepository(),
    private val certRepo: HttpsCertRepository = HttpsCertRepository(),
)
```

#### B. Update the `when` block in `executeSingleCommand()`

```kotlin
return when {
    prefix == "ping"            -> executePing(name, trimmed, parts)
    prefix == "dig"             -> executeDig(name, trimmed)
    prefix == "ntp"             -> executeNtp(name, trimmed)
    prefix == "port-scan"       -> executePortScan(name, trimmed)     // renamed
    prefix == "checkcert"       -> executeCheckcert(name, trimmed)
    prefix == "device-info"     -> executeDeviceInfo(name, trimmed)   // NEW
    prefix == "tracert"         -> executeTracert(name, trimmed)      // NEW
    prefix == "google-timesync" -> executeGoogleTimeSync(name, trimmed) // NEW
    prefix == "lan-scan"        -> executeLanScan(name, trimmed)      // NEW
    else                        -> executeRaw(name, trimmed)
}
```

#### C. Rename `executeNmap` → `executePortScan`

Copy the body verbatim, update the doc comment and the method name. No logic changes.

#### D. Implement `executeDeviceInfo(name, cmd)`

```kotlin
private suspend fun executeDeviceInfo(name: String, cmd: String): BulkCommandResult {
    return withContext(Dispatchers.IO) {
        try {
            val t0 = System.currentTimeMillis()
            val repo = SystemInfoRepository(context)
            val di = repo.getDeviceInfo()
            val dur = System.currentTimeMillis() - t0

            val lines = buildList {
                add("[${timestampFmt(LocalDateTime.now())}] $cmd")
                add("[${timestampFmt(LocalDateTime.now())}] Status: SUCCESS (${dur}ms)")
                add("  Device Name: ${di.deviceName}")
                add("  Android Version: ${di.androidVersion}")
                add("  API Level: ${di.apiLevel}")
                add("  IPv4: ${di.ipv4Address ?: "N/A"}")
                add("  IPv6: ${di.ipv6Address ?: "N/A"}")
                add("  Subnet Mask: ${di.subnetMask ?: "N/A"}")
                add("  Default Gateway: ${di.defaultGateway ?: "N/A"}")
                add("  NTP Server: ${di.ntpServer ?: "N/A"}")
                add("  DNS Servers: ${di.dnsServers?.joinToString(", ") ?: "N/A"}")
                add("  Carrier: ${di.carrierName ?: "N/A"}")
                add("  Wi-Fi SSID: ${di.wifiSSID ?: "N/A"}")
                add("  Battery Level: ${di.batteryLevel ?: "N/A"}%")
                add("  Charging: ${di.isCharging ?: "N/A"}")
                add("  Battery Health: ${di.batteryHealth ?: "N/A"}")
                add("  Time Since Reboot: ${di.timeSinceReboot}")
                add("  IMEI: ${di.imei ?: "Restricted by Android 10+"}")
                add("  Serial: ${di.serialNumber ?: "Restricted by Android 10+"}")
                add("  ICCID: ${di.iccid ?: "Restricted by Android 10+"}")
                add("  Total RAM: ${di.totalRam ?: "N/A"}")
                add("  Available RAM: ${di.availableRam ?: "N/A"}")
                add("  Total Storage: ${di.totalStorage ?: "N/A"}")
                add("  Available Storage: ${di.availableStorage ?: "N/A"}")
                add("  CPU ABI: ${di.cpuAbi?.joinToString(", ") ?: "N/A"}")
                add("  Active Network: ${di.activeNetworkType ?: "N/A"}")
            }
            BulkCommandSuccess(name, cmd, lines, dur)
        } catch (e: Exception) {
            BulkCommandError(name, cmd, e.message ?: "Unknown error")
        }
    }
}
```

#### E. Implement `executeTracert(name, cmd)`

Inline TTL-probing logic (same as `TracerouteScreen`):

```kotlin
private suspend fun executeTracert(name: String, cmd: String): BulkCommandResult {
    return withContext(Dispatchers.IO) {
        try {
            val parts = cmd.split(Regex("\\s+"))
            val host = parts.getOrNull(1)
                ?: return@withContext BulkCommandError(name, cmd, "Usage: tracert <host>")

            val t0 = System.currentTimeMillis()
            val out = mutableListOf<String>()
            var dstReached = false
            var hops = 0

            out.add("[${timestampFmt(LocalDateTime.now())}] $cmd")
            out.add("traceroute to $host, 30 hops max")

            val ttlIpRegex = Regex("""From (\S+).*[Tt]ime to live exceeded""")
            val dstReplyRegex = Regex("""bytes from (\S+):""")
            val ttlAltRegex = Regex("""From (\S+):.*ttl""", RegexOption.IGNORE_CASE)

            for (ttl in 1..30) {
                val num = ttl.toString().padStart(2)
                try {
                    val proc = Runtime.getRuntime().exec(
                        arrayOf("ping", "-c", "1", "-t", ttl.toString(), "-W", "2", host)
                    )
                    val stdout = proc.inputStream.bufferedReader().readText()
                    val stderr = proc.errorStream.bufferedReader().readText()
                    proc.waitFor()
                    val elapsed = System.currentTimeMillis() - t0
                    val combined = stdout + "\n" + stderr

                    when {
                        ttlIpRegex.containsMatchIn(combined) -> {
                            val ip = ttlIpRegex.find(combined)!!.groupValues[1].trimEnd(':')
                            out.add("$num  $ip  ${elapsed} ms")
                            hops++
                        }
                        dstReplyRegex.containsMatchIn(combined) -> {
                            val ip = dstReplyRegex.find(combined)!!.groupValues[1].trimEnd(':')
                            val rtt = Regex("""time[=<]([\d.]+) ms""").find(combined)
                                ?.groupValues?.get(1)?.let { "$it ms" } ?: "${elapsed} ms"
                            out.add("$num  $ip  $rtt")
                            hops++
                            dstReached = true
                            break
                        }
                        ttlAltRegex.containsMatchIn(combined) -> {
                            val ip = ttlAltRegex.find(combined)!!.groupValues[1].trimEnd(':')
                            out.add("$num  $ip  ${elapsed} ms")
                            hops++
                        }
                        else -> out.add("$num  * * *")
                    }
                } catch (_: Exception) {
                    out.add("$num  * * *")
                }
            }

            val dur = System.currentTimeMillis() - t0
            out.add("[${timestampFmt(LocalDateTime.now())}] Status: COMPLETE (${dur}ms)")
            out.add("  Reachable hops: $hops, Destination reached: $dstReached")
            BulkCommandSuccess(name, cmd, out, dur)
        } catch (e: Exception) {
            BulkCommandError(name, cmd, e.message ?: "Unknown error")
        }
    }
}
```

#### F. Implement `executeGoogleTimeSync(name, cmd)`

```kotlin
private suspend fun executeGoogleTimeSync(name: String, cmd: String): BulkCommandResult {
    return withContext(Dispatchers.IO) {
        try {
            val t0 = System.currentTimeMillis()
            val repo = GoogleTimeSyncRepository()
            val result = repo.fetchGoogleTime()
            val dur = System.currentTimeMillis() - t0

            val lines = buildList {
                add("[${timestampFmt(LocalDateTime.now())}] $cmd")
                when (result) {
                    is GoogleTimeSyncResult.Success -> {
                        add("[${timestampFmt(LocalDateTime.now())}] Status: SUCCESS (${dur}ms)")
                        add("  Server Time:  ${Date(result.data.serverTimeMillis)}")
                        add("  RTT:          ${result.data.rttMillis} ms")
                        add("  Offset:       ${result.data.offsetMillis} ms")
                        add("  Corrected:    ${Date(result.data.correctedServerTimeMillis)}")
                    }
                    is GoogleTimeSyncResult.NoNetwork ->
                        add("[${timestampFmt(LocalDateTime.now())}] Status: NO NETWORK (${dur}ms)")
                    is GoogleTimeSyncResult.Timeout ->
                        add("[${timestampFmt(LocalDateTime.now())}] Status: TIMEOUT (${dur}ms)")
                    is GoogleTimeSyncResult.HttpError ->
                        add("[${timestampFmt(LocalDateTime.now())}] Status: HTTP ${result.code} (${dur}ms)")
                    is GoogleTimeSyncResult.ParseError ->
                        add("[${timestampFmt(LocalDateTime.now())}] Status: PARSE ERROR - ${result.message} (${dur}ms)")
                    is GoogleTimeSyncResult.Error ->
                        add("[${timestampFmt(LocalDateTime.now())}] Status: ERROR - ${result.message} (${dur}ms)")
                }
            }
            BulkCommandSuccess(name, cmd, lines, dur)
        } catch (e: Exception) {
            BulkCommandError(name, cmd, e.message ?: "Unknown error")
        }
    }
}
```

#### G. Implement `executeLanScan(name, cmd)`

```kotlin
private suspend fun executeLanScan(name: String, cmd: String): BulkCommandResult {
    return withContext(Dispatchers.IO) {
        try {
            val t0 = System.currentTimeMillis()
            val repo = LanScannerRepository(context)
            val subnet = repo.getLocalSubnetInfo()
                ?: return@withContext BulkCommandError(name, cmd, "No active WiFi network found")

            val out = mutableListOf<String>()
            out.add("[${timestampFmt(LocalDateTime.now())}] $cmd")
            out.add("[${timestampFmt(LocalDateTime.now())}] Subnet: ${subnet.cidr}")
            out.add("[${timestampFmt(LocalDateTime.now())}] Scanning up to 256 hosts…")

            val devices = mutableListOf<String>()
            val limit = minOf(subnet.numHosts, 256L)
            for (i in 0 until limit) {
                val ip = repo.longToIp(subnet.baseIp + i + 1)
                val rtt = repo.ping(ip) ?: continue
                val mac = repo.getMacFromArpTable(ip)
                val host = repo.resolveHostname(ip)
                val isRouter = (i == 0)

                val info = buildString {
                    append(ip)
                    mac?.let { append(" MAC:$it") }
                    host?.let { append(" Host:$it") }
                    append(" RTT:${rtt}ms")
                    if (isRouter) append(" [ROUTER]")
                }
                devices.add(info)
            }

            val dur = System.currentTimeMillis() - t0
            out.add("[${timestampFmt(LocalDateTime.now())}] Status: COMPLETE (${dur}ms)")
            out.add("  Devices found: ${devices.size}")
            devices.forEach { out.add("  $it") }
            BulkCommandSuccess(name, cmd, out, dur)
        } catch (e: Exception) {
            BulkCommandError(name, cmd, e.message ?: "Unknown error")
        }
    }
}
```

---

### 2. `BulkActionsViewModel.kt` — Minor changes

#### A. Update the factory to pass `Context` to repository

```kotlin
companion object {
    fun factory(context: Context): ViewModelProvider.Factory =
        object : ViewModelProvider.Factory {
            @Suppress("UNCHECKED_CAST")
            override fun <T : ViewModel> create(modelClass: Class<T>): T =
                BulkActionsViewModel(
                    context = context.applicationContext,
                    repository = BulkActionsRepository(context.applicationContext),  // ← pass Context
                ) as T
        }
}
```

---

### 3. `BulkConfigParserTest.kt` — Minor update

Change the test that references `nmap`:

```kotlin
// Before:
"cmd5": "nmap -p 80-443 mobilutils.com"

// After:
"cmd5": "port-scan -p 80-443 mobilutils.com"
```

---

### 4. `README.md` — Minor update

Update the Bulk Actions section to list all supported commands:

```markdown
### ⚡ Bulk Actions

- Supports built-in command types: `ping`, `dig`, `ntp`, `port-scan`, `checkcert`, `device-info`, `tracert`, `google-timesync`, `lan-scan`
```

---

### 5. `notes/20260425_BulkActions-viaLocalConfigFile.md` — Minor update

Update the command mapping table to include new commands and note the `nmap` → `port-scan` rename.

---

## Example Config File

```json
{
  "output-file": "~/Downloads/bulk-output.txt",
  "run": {
    "info": "device-info",
    "trace_google": "tracert google.com",
    "time_sync": "google-timesync",
    "local_network": "lan-scan",
    "port_scan_1": "port-scan -p 80,443 google.com",
    "port_scan_2": "port-scan -p 22-8080 example.com"
  }
}
```

---

## Test Updates

### New tests to add to `BulkActionsRepositoryTest.kt` (or extend existing)

| Test | What it verifies |
|---|---|
| `executeDeviceInfo_success` | Returns `BulkCommandSuccess` with device fields |
| `executeDeviceInfo_exception` | Returns `BulkCommandError` on repo failure |
| `executeTracert_success` | Parses TTL hops, detects destination |
| `executeTracert_missingHost` | Returns error: "Usage: tracert \<host\>" |
| `executeGoogleTimeSync_success` | Returns server time, RTT, offset |
| `executeGoogleTimeSync_noNetwork` | Returns `NoNetwork` mapped to error line |
| `executeLanScan_success` | Returns device list from subnet |
| `executeLanScan_noNetwork` | Returns error: "No active WiFi network found" |
| `executePortScan_success` | Parses `-p ports host`, reports open ports |
| `nmap_noLongerRecognized` | Prefix `nmap` falls through to `executeRaw` |

---

## Permissions Required

All new commands reuse permissions already declared in `AndroidManifest.xml`:

| Permission | Used by |
|---|---|
| `INTERNET` | All commands |
| `ACCESS_NETWORK_STATE` | LAN scan subnet detection |
| `ACCESS_WIFI_STATE` | LAN scan WiFi detection |
| `ACCESS_COARSE_LOCATION` / `ACCESS_FINE_LOCATION` | LAN scan SSID |
| `READ_PHONE_STATE` | Device info IMEI/ICCID (restricted Android 10+) |

---

## Files to Modify

| File | Change | Description |
|---|---|---|
| `BulkActionsRepository.kt` | **Major** | Add `Context` param, rename `nmap`→`port-scan`, add 4 executors |
| `BulkActionsViewModel.kt` | **Minor** | Pass `Context` to `BulkActionsRepository()` in factory |
| `BulkConfigParserTest.kt` | **Minor** | Update `nmap` reference to `port-scan` |
| `README.md` | **Minor** | Update command list in Bulk Actions section |
| `notes/20260425_BulkActions-viaLocalConfigFile.md` | **Minor** | Update command mapping table |

---

## Risk & Edge Cases

1. **Context lifecycle** — `BulkActionsRepository` now holds a `Context`. The ViewModel factory passes `context.applicationContext` to avoid memory leaks.

2. **Traceroute on Android** — Uses `ping -c 1 -t TTL` which requires root or `CAP_NET_RAW`. On non-rooted devices, TTL probes may always fail → output will show `* * *` for each hop. This is expected Android behavior.

3. **LAN scan performance** — Limited to 256 hosts (effectively a /24) to avoid extremely long scans on larger subnets.

4. **Breaking change** — `nmap` prefix no longer works. Any saved config files or user bookmarks referencing `nmap` will fall through to `executeRaw`, which will fail with exit code 127 ("command not found"). Consider adding a deprecation warning in a future release.

---

## Implementation Order (recommended)

1. Rename `executeNmap` → `executePortScan` in `BulkActionsRepository.kt`
2. Add `Context` parameter to `BulkActionsRepository` constructor
3. Add the 4 new `when` branches + executor methods to `executeSingleCommand()`
4. Implement `executeDeviceInfo`, `executeTracert`, `executeGoogleTimeSync`, `executeLanScan`
5. Update `BulkActionsViewModel.factory()` to pass `Context`
6. Update `BulkConfigParserTest.kt` (nmap → port-scan)
7. Update `README.md` and notes files
8. Add unit tests for new executors
