### PR TITLE
# Bulk Actions: `-t` Timeout Support — Walkthrough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ captures/
 # -- Keystore
 .keystore/
 
+# -- Me related -----------------------------------------------------------------
+troubleshooting/
+
 # -- QWEN RELATED ---------------------------------------------------------------
 .qwen/
 node_modules/

--- a/README.md
+++ b/README.md
@@ -125,6 +125,22 @@ connect.hostinger.com.   120  IN  A      34.120.137.41
 - **"Write to File"** button launches an SAF picker for manual save location selection
 - Graceful error handling: invalid JSON, unwritable paths, network failures — all captured and displayed without crashing
 
+#### Supported Pseudo-Commands
+
+| Command | Syntax | Description |
+|---|---|-:--|
+| `ping` | `ping -c N [-t W] host` | ICMP ping (N packets, -t W = per-packet wait in seconds + coroutine timeout) |
+| `dig` | `dig @server fqdn [-t T]` | DNS lookup to custom server (-t T = coroutine timeout in seconds) |
+| `ntp` | `ntp [pool] [-t T]` | NTP query (-t T = coroutine timeout in seconds) |
+| `port-scan` | `port-scan -p ports [-t S] host` | TCP port scan (-t S = connect timeout per port in seconds) |
+| `checkcert` | `checkcert -p port [-t T] host` | HTTPS certificate check (-t T = coroutine timeout in seconds) |
+| `device-info` | `device-info` | Device identity, network, battery, storage (no -t) |
+| `tracert` | `tracert host [-t H]` | TTL-probing traceroute (-t H = max hops, also sets coroutine timeout) |
+| `google-timesync` | `google-timesync` | Google time sync (no -t) |
+| `lan-scan` | `lan-scan` | LAN subnet device discovery (no -t) |
+
+**Timeout precedence:** per-command `-t` > config-level `"timeout"` > default 30s.
+
 ## Stack
 
 | Layer | Technology |

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
@@ -27,10 +27,12 @@ import java.util.concurrent.atomic.AtomicBoolean
  *
  * @param outputFile  Optional expanded output file path (null = don't write to file).
  * @param commands    Ordered command map (key = command name, value = command string).
+ * @param timeoutMs   Optional per-command timeout in milliseconds (null = use default 30s).
  */
 data class BulkConfig(
     val outputFile: String?,
     val commands: Map<String, String>,
+    val timeoutMs: Long? = null,
 )
 
 /**
@@ -74,6 +76,20 @@ data class BulkProgress(
 object BulkConfigParser {
 
     /**
+     * Parses a per-command `-t N` timeout from the command string.
+     * Returns the timeout in milliseconds, or null if not present.
+     * Example: "ping -c 4 -t 10 google.com" → 10_000L
+     */
+    fun extractCommandTimeout(cmd: String): Long? {
+        val parts = cmd.trim().split(Regex("\\s+"))
+        val tIdx = parts.indexOf("-t")
+        if (tIdx >= 0 && tIdx < parts.size - 1) {
+            return parts[tIdx + 1].toLongOrNull()?.takeIf { it > 0 }?.let { it * 1000L }
+        }
+        return null
+    }
+
+    /**
      * Parses a JSON string into a [BulkConfig].
      *
      * Expected structure:
@@ -97,6 +113,12 @@ object BulkConfigParser {
             else expandTilde(path)
         }.getOrNull()
 
+        val timeoutMs = runCatching {
+            val seconds = root.optLong("timeout", 0L)
+            if (seconds == null || seconds <= 0) null
+            else seconds * 1000L
+        }.getOrNull()
+
         val runObj = root.optJSONObject("run")
             ?: throw IllegalArgumentException("Missing required 'run' object in configuration")
 
@@ -110,7 +132,7 @@ object BulkConfigParser {
             }
         }
 
-        return BulkConfig(outputFile, commands)
+        return BulkConfig(outputFile, commands, timeoutMs)
     }
 
     /** Expands `~` to the external storage directory path. */
@@ -191,6 +213,20 @@ class BulkActionsRepository(
     private val timestampFmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
 
     /**
+     * Parses a per-command `-t N` timeout from the command string.
+     * Returns the timeout in milliseconds, or null if not present.
+     * Example: "ping -c 4 -t 10 google.com" → 10_000L
+     */
+    private fun extractCommandTimeout(cmd: String): Long? {
+        val parts = cmd.trim().split(Regex("\\s+"))
+        val tIdx = parts.indexOf("-t")
+        if (tIdx >= 0 && tIdx < parts.size - 1) {
+            return parts[tIdx + 1].toLongOrNull()?.takeIf { it > 0 }?.let { it * 1000L }
+        }
+        return null
+    }
+
+    /**
      * Executes all commands in [config] sequentially.
      */
     suspend fun executeCommands(
@@ -201,14 +237,21 @@ class BulkActionsRepository(
         val results = mutableListOf<BulkCommandResult>()
         val commands = config.commands.toList()
         val total = commands.size
+        val defaultTimeoutMs = config.timeoutMs ?: 30_000L
 
         commands.forEachIndexed { index, (name, cmd) ->
-            if (cancellationToken.get()) return results
+            if (cancellationToken.get()) {
+                results.add(BulkCommandTimeout(name, cmd))
+                return@forEachIndexed
+            }
 
             onProgress?.invoke(BulkProgress(index, total, name, cmd))
 
-            val result = withTimeoutOrNull(30_000) {
-                executeSingleCommand(name, cmd)
+            // Per-command `-t N` overrides config-level timeout
+            val commandTimeoutMs = extractCommandTimeout(cmd) ?: defaultTimeoutMs
+
+            val result = withTimeoutOrNull(commandTimeoutMs) {
+                executeSingleCommand(name, cmd, commandTimeoutMs)
             }
 
             val finalResult = result ?: BulkCommandTimeout(name, cmd)
@@ -218,32 +261,68 @@ class BulkActionsRepository(
         return results
     }
 
-    suspend fun executeSingleCommand(name: String, cmd: String): BulkCommandResult {
+    suspend fun executeSingleCommand(name: String, cmd: String, timeoutMs: Long? = null): BulkCommandResult {
         val trimmed = cmd.trim()
         val parts = trimmed.split(Regex("\\s+"))
         val prefix = parts.firstOrNull()?.lowercase() ?: ""
 
         return when {
-            prefix == "ping"            -> executePing(name, trimmed, parts)
-            prefix == "dig"             -> executeDig(name, trimmed)
-            prefix == "ntp"             -> executeNtp(name, trimmed)
-            prefix == "port-scan"       -> executePortScan(name, trimmed)
-            prefix == "checkcert"       -> executeCheckcert(name, trimmed)
+            prefix == "ping"            -> executePing(name, trimmed, parts, timeoutMs)
+            prefix == "dig"             -> executeDig(name, trimmed, timeoutMs)
+            prefix == "ntp"             -> executeNtp(name, trimmed, timeoutMs)
+            prefix == "port-scan"       -> executePortScan(name, trimmed, timeoutMs)
+            prefix == "checkcert"       -> executeCheckcert(name, trimmed, timeoutMs)
             prefix == "device-info"     -> executeDeviceInfo(name, trimmed)
-            prefix == "tracert"         -> executeTracert(name, trimmed)
-            prefix == "google-timesync" -> executeGoogleTimeSync(name, trimmed)
-            prefix == "lan-scan"        -> executeLanScan(name, trimmed)
-            else                        -> executeRaw(name, trimmed)
+            prefix == "tracert"         -> executeTracert(name, trimmed, timeoutMs)
+            prefix == "google-timesync" -> executeGoogleTimeSync(name, trimmed, timeoutMs)
+            prefix == "lan-scan"        -> executeLanScan(name, trimmed, timeoutMs)
+            else                        -> executeRaw(name, trimmed, timeoutMs)
         }
     }
 
-    // ── ping ────────────────────────────────────────────────────────────
+    // ── ping ───────────────────────────────────────────────────────
 
-    private suspend fun executePing(name: String, cmd: String, parts: List<String>): BulkCommandResult {
+    private suspend fun executePing(name: String, cmd: String, parts: List<String>, timeoutMs: Long?): BulkCommandResult {
         return withContext(Dispatchers.IO) {
             try {
                 val t0 = System.currentTimeMillis()
-                val process = Runtime.getRuntime().exec(arrayOf("ping", "-c", "4", parts.last()))
+
+                // Parse -c count (default 4)
+                val countIdx = parts.indexOf("-c")
+                val count = if (countIdx >= 0 && countIdx < parts.size - 1) {
+                    parts[countIdx + 1].toIntOrNull() ?: 4
+                } else {
+                    4
+                }
+
+                // Parse -t timeout (default 0 = no per-packet timeout)
+                val timeoutIdx = parts.indexOf("-t")
+                val timeout = if (timeoutIdx >= 0 && timeoutIdx < parts.size - 1) {
+                    parts[timeoutIdx + 1].toIntOrNull() ?: 0
+                } else {
+                    0
+                }
+
+                // Host = first non-flag argument after skipping flag-value pairs (works regardless of -t position)
+                val host = run {
+                    var i = 1
+                    val flags = setOf("-c", "-t", "-W", "-i", "-I", "-D", "-S", "-p", "-f", "-q", "-C", "-N", "-R", "-r", "-l", "-L", "-M", "-n", "-O", "-s", "-T", "-v")
+                    while (i < parts.size) {
+                        if (parts[i] in flags && i + 1 < parts.size) i += 2
+                        else if (parts[i].startsWith("-")) i++
+                        else break
+                    }
+                    parts.getOrNull(i) ?: parts.last()
+                }
+
+                val pingArgs = mutableListOf("ping", "-c", count.toString())
+                if (timeout > 0) {
+                    pingArgs.add("-W")
+                    pingArgs.add(timeout.toString())
+                }
+                pingArgs.add(host)
+
+                val process = Runtime.getRuntime().exec(pingArgs.toTypedArray())
                 val output = process.inputStream.bufferedReader().readLines()
                 val exitCode = process.waitFor()
                 val duration = System.currentTimeMillis() - t0
@@ -260,13 +339,13 @@ class BulkActionsRepository(
         }
     }
 
-    // ── dig ─────────────────────────────────────────────────────────────
+    // ── dig ───────────────────────────────────────────────────────────────
 
-    private suspend fun executeDig(name: String, cmd: String): BulkCommandResult {
+    private suspend fun executeDig(name: String, cmd: String, timeoutMs: Long?): BulkCommandResult {
         return withContext(Dispatchers.IO) {
             try {
                 val t0 = System.currentTimeMillis()
-                // Parse: dig @server fqdn
+                // Parse: dig @server fqdn [-t timeout]
                 val parts = cmd.split(Regex("\\s+"))
                 val serverIdx = parts.indexOfFirst { it == "@" }
                 val (server, fqdn) = if (serverIdx > 0 && serverIdx < parts.size - 1) {
@@ -304,9 +383,9 @@ class BulkActionsRepository(
         }
     }
 
-    // ── ntp ─────────────────────────────────────────────────────────────
+    // ── ntp ─────────────────────────────────────────────────────────────────
 
-    private suspend fun executeNtp(name: String, cmd: String): BulkCommandResult {
+    private suspend fun executeNtp(name: String, cmd: String, timeoutMs: Long?): BulkCommandResult {
         return withContext(Dispatchers.IO) {
             try {
                 val t0 = System.currentTimeMillis()
@@ -342,17 +421,30 @@ class BulkActionsRepository(
         }
     }
 
-    // ── port-scan (formerly nmap) ────────────────────────────────────────────────
+    // ── port-scan (formerly nmap) ───────────────────────────────────────
 
-    private suspend fun executePortScan(name: String, cmd: String): BulkCommandResult {
+    private suspend fun executePortScan(name: String, cmd: String, timeoutMs: Long?): BulkCommandResult {
         return withContext(Dispatchers.IO) {
             try {
                 val t0 = System.currentTimeMillis()
-                // Parse: nmap -p ports host
+                // Parse: port-scan -p ports [-t timeout] host
                 val parts = cmd.split(Regex("\\s+"))
-                val portStr = parts.getOrNull(parts.indexOfFirst { it == "-p" } + 1) ?: "22"
-                val host = parts.getOrNull(parts.indexOfFirst { it == "-p" } + 2)
-                    ?: parts.last()
+                val portIdx = parts.indexOfFirst { it == "-p" }
+                val portStr = parts.getOrNull(portIdx + 1) ?: "22"
+                // Parse host: everything after -t N (if present) that's not a flag
+                val host = run {
+                    val tIdx2 = parts.indexOf("-t")
+                    val startIdx = if (tIdx2 >= portIdx) tIdx2 + 2 else portIdx + 2
+                    parts.subList(startIdx, parts.size).lastOrNull() ?: parts.last()
+                }
+
+                // Parse per-command -t timeout (default 2000ms per port)
+                val tIdx = parts.indexOf("-t")
+                val connectTimeout = if (tIdx >= 0 && tIdx < parts.size - 1) {
+                    parts[tIdx + 1].toIntOrNull()?.times(1000) ?: 2000
+                } else {
+                    timeoutMs ?: 2000L
+                }.toInt()
 
                 val ports = parsePortRange(portStr)
                 val openPorts = mutableListOf<Int>()
@@ -360,7 +452,7 @@ class BulkActionsRepository(
                 ports.forEach { port ->
                     try {
                         val socket = Socket()
-                        socket.connect(InetSocketAddress(host, port), 2000)
+                        socket.connect(InetSocketAddress(host, port), connectTimeout)
                         socket.close()
                         openPorts.add(port)
                     } catch (_: Exception) {
@@ -385,17 +477,23 @@ class BulkActionsRepository(
         }
     }
 
-    // ── checkcert ───────────────────────────────────────────────────────
+    // ── checkcert ────────────────────────────────────────────────────────
 
-    private suspend fun executeCheckcert(name: String, cmd: String): BulkCommandResult {
+    private suspend fun executeCheckcert(name: String, cmd: String, timeoutMs: Long?): BulkCommandResult {
         return withContext(Dispatchers.IO) {
             try {
                 val t0 = System.currentTimeMillis()
-                // Parse: checkcert -p port host
+                // Parse: checkcert -p port [-t timeout] host
                 val parts = cmd.split(Regex("\\s+"))
                 val portIdx = parts.indexOfFirst { it == "-p" }
                 val port = parts.getOrNull(portIdx + 1)?.toIntOrNull() ?: 443
-                val host = parts.getOrNull(portIdx + 2) ?: parts.last()
+                // Skip -t N if present between port and host
+                val tIdx = parts.indexOf("-t")
+                val host = if (tIdx > portIdx && tIdx < parts.size - 1) {
+                    parts.getOrNull(tIdx + 2) ?: parts.last()
+                } else {
+                    parts.getOrNull(portIdx + 2) ?: parts.last()
+                }
 
                 val result = certRepo.fetchCertificate(host, port)
                 val duration = System.currentTimeMillis() - t0
@@ -485,12 +583,20 @@ class BulkActionsRepository(
 
     // ── tracert ─────────────────────────────────────────────────────────
 
-    private suspend fun executeTracert(name: String, cmd: String): BulkCommandResult {
+    private suspend fun executeTracert(name: String, cmd: String, timeoutMs: Long?): BulkCommandResult {
         return withContext(Dispatchers.IO) {
             try {
                 val parts = cmd.split(Regex("\\s+"))
                 val host = parts.getOrNull(1)
                     ?: return@withContext BulkCommandError(name, cmd, "Usage: tracert <host>")
+
+                // Parse per-command -t as max hops (default 30)
+                val tIdx = parts.indexOf("-t")
+                val maxHops = if (tIdx >= 0 && tIdx < parts.size - 1) {
+                    parts[tIdx + 1].toIntOrNull()?.takeIf { it > 0 } ?: 30
+                } else {
+                    timeoutMs?.toInt()?.takeIf { it > 0 } ?: 30
+                }
 
                 val t0 = System.currentTimeMillis()
                 val out = mutableListOf<String>()
@@ -498,13 +604,13 @@ class BulkActionsRepository(
                 var hops = 0
 
                 out.add("[${timestampFmt.format(LocalDateTime.now())}] $cmd")
-                out.add("traceroute to $host, 30 hops max")
+                out.add("traceroute to $host, $maxHops hops max")
 
                 val ttlIpRegex = Regex("""From (\S+).*[Tt]ime to live exceeded""")
                 val dstReplyRegex = Regex("""bytes from (\S+):""")
                 val ttlAltRegex = Regex("""From (\S+):.*ttl""", RegexOption.IGNORE_CASE)
 
-                for (ttl in 1..30) {
+                for (ttl in 1..maxHops) {
                     val num = ttl.toString().padStart(2)
                     try {
                         val proc = Runtime.getRuntime().exec(
@@ -555,7 +661,7 @@ class BulkActionsRepository(
 
     // ── google-timesync ─────────────────────────────────────────────────
 
-    private suspend fun executeGoogleTimeSync(name: String, cmd: String): BulkCommandResult {
+    private suspend fun executeGoogleTimeSync(name: String, cmd: String, timeoutMs: Long?): BulkCommandResult {
         return withContext(Dispatchers.IO) {
             try {
                 val t0 = System.currentTimeMillis()
@@ -594,7 +700,7 @@ class BulkActionsRepository(
 
     // ── lan-scan ────────────────────────────────────────────────────────
 
-    private suspend fun executeLanScan(name: String, cmd: String): BulkCommandResult {
+    private suspend fun executeLanScan(name: String, cmd: String, timeoutMs: Long?): BulkCommandResult {
         return withContext(Dispatchers.IO) {
             try {
                 val t0 = System.currentTimeMillis()
@@ -638,9 +744,9 @@ class BulkActionsRepository(
         }
     }
 
-    // ── raw ─────────────────────────────────────────────────────────────
+    // ── raw ────────────────────────────────────────────────────────────────
 
-    private suspend fun executeRaw(name: String, cmd: String): BulkCommandResult {
+    private suspend fun executeRaw(name: String, cmd: String, timeoutMs: Long?): BulkCommandResult {
         return withContext(Dispatchers.IO) {
             try {
                 val t0 = System.currentTimeMillis()

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsScreen.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsScreen.kt
@@ -193,8 +193,9 @@ fun BulkActionsScreen() {
                         color = MaterialTheme.colorScheme.onPrimaryContainer,
                     )
                     Spacer(Modifier.height(4.dp))
+                    val timeoutText = uiState.configTimeoutMs?.let { " · ${it / 1000}s timeout" } ?: ""
                     Text(
-                        text = "${uiState.configFileName} — ${uiState.commandCount} command(s)",
+                        text = "${uiState.configFileName} — ${uiState.commandCount} command(s)$timeoutText",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onPrimaryContainer,
                     )
@@ -391,7 +392,7 @@ fun BulkActionsScreen() {
                             verticalArrangement = Arrangement.spacedBy(2.dp),
                         ) {
                             itemsIndexed(uiState.results) { index, result ->
-                                ResultItem(result)
+                                ResultItem(result, configTimeoutMs = uiState.configTimeoutMs)
                             }
                         }
                     }
@@ -514,7 +515,7 @@ fun BulkActionsScreen() {
 // ────────────────────────────────────────────────────────────────────
 
 @Composable
-private fun ResultItem(result: BulkCommandResult) {
+private fun ResultItem(result: BulkCommandResult, configTimeoutMs: Long? = null) {
     val (icon, statusText, statusColor) = when (result) {
         is BulkCommandSuccess ->
             Triple(Icons.Filled.CheckCircle, "SUCCESS", MaterialTheme.colorScheme.secondary)
@@ -580,8 +581,9 @@ private fun ResultItem(result: BulkCommandResult) {
                     ),
                 )
             } else if (result is BulkCommandTimeout) {
+                val timeoutSec = configTimeoutMs?.let { "${it / 1000}s" } ?: "30s"
                 Text(
-                    text = "Command timed out after 30 seconds",
+                    text = "Command timed out after $timeoutSec",
                     style = MaterialTheme.typography.bodySmall.copy(
                         fontFamily = FontFamily.Monospace,
                         fontStyle = FontStyle.Italic,

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsViewModel.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsViewModel.kt
@@ -25,6 +25,7 @@ data class BulkUiState(
     val configFileName: String? = null,
     val configUri: String? = null,
     val commandCount: Int = 0,
+    val configTimeoutMs: Long? = null,
     val isExecuting: Boolean = false,
     val currentCommand: String? = null,
     val progress: Float = 0f,
@@ -70,6 +71,7 @@ class BulkActionsViewModel(
                     configFileName = fileName,
                     configUri = uri.toString(),
                     commandCount = config.commands.size,
+                    configTimeoutMs = config.timeoutMs,
                     results = emptyList(),
                     progress = 0f,
                     outputFileWritten = null,
@@ -110,6 +112,7 @@ class BulkActionsViewModel(
 
             val commands = config.commands.toList()
             val total = commands.size
+            val defaultTimeoutMs = config.timeoutMs ?: 30_000L
             val allResults = mutableListOf<BulkCommandResult>()
 
             commands.forEachIndexed { index, (name, cmd) ->
@@ -124,9 +127,12 @@ class BulkActionsViewModel(
                     progress = index.toFloat() / total,
                 )
 
+                // Per-command `-t N` overrides config-level timeout
+                val commandTimeoutMs = BulkConfigParser.extractCommandTimeout(cmd) ?: defaultTimeoutMs
+
                 val result = try {
-                    withTimeout(30_000L) {
-                        repository.executeSingleCommand(name, cmd)
+                    withTimeout(commandTimeoutMs) {
+                        repository.executeSingleCommand(name, cmd, commandTimeoutMs)
                     }
                 } catch (e: Exception) {
                     null

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsViewModelTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsViewModelTest.kt
@@ -53,6 +53,7 @@ class BulkActionsViewModelTest {
         assertTrue(state.results.isEmpty())
         assertFalse(state.isFileWriting)
         assertNull(state.outputFileWritten)
+        assertNull(state.configTimeoutMs)
     }
 
     @Test
@@ -92,5 +93,10 @@ class BulkActionsViewModelTest {
 
         // Original state object should be unchanged
         assertEquals(initial.configLoaded, viewModel.uiState.value.configLoaded)
+    }
+
+    @Test
+    fun `initialState_configTimeoutMsDefaultsToNull`() = runTest {
+        assertNull(viewModel.uiState.value.configTimeoutMs)
     }
 }

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkConfigParserTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkConfigParserTest.kt
@@ -27,6 +27,9 @@ class BulkConfigParserTest {
         // Extract "output-file" value (supports both quoted and unquoted)
         val outputFile = extractStringField(trimmed, "output-file")
 
+        // Extract "timeout" value (mirrors production parsing)
+        val timeoutMs = extractLongField(trimmed, "timeout")?.takeIf { it > 0 }?.let { it * 1000L }
+
         // Extract "run" object
         val runMatch = Regex("""\"run\"\s*:\s*\{([^}]*)\}""").find(trimmed)
             ?: throw IllegalArgumentException("Missing required 'run' object in configuration")
@@ -43,7 +46,14 @@ class BulkConfigParserTest {
             }
         }
 
-        return BulkConfig(outputFile, commands)
+        return BulkConfig(outputFile, commands, timeoutMs)
+    }
+
+    /** Extracts a long field value from JSON, returning null if not found. */
+    private fun extractLongField(json: String, fieldName: String): Long? {
+        val pattern = Regex("""\"$fieldName\"\s*:\s*(-?\d+)""")
+        val match = pattern.find(json)
+        return match?.groupValues?.getOrNull(1)?.toLongOrNull()
     }
 
     /** Extracts a string field value from JSON, returning null if not found. */
@@ -212,5 +222,92 @@ class BulkConfigParserTest {
         val config = parseBulkConfig(json)
 
         assertEquals("ping -c 1 example.com", config.commands["cmd1"])
+    }
+
+    @Test
+    fun `parseConfigWithTimeout returns timeoutMs`() {
+        val json = """
+            {
+                "timeout": 60,
+                "run": {
+                    "cmd1": "ping -c 1 example.com"
+                }
+            }
+        """.trimIndent()
+
+        val config = parseBulkConfig(json)
+
+        assertEquals(60_000L, config.timeoutMs)
+    }
+
+    @Test
+    fun `parseConfigWithoutTimeout returns null`() {
+        val json = """
+            {
+                "run": {
+                    "cmd1": "ping -c 1 example.com"
+                }
+            }
+        """.trimIndent()
+
+        val config = parseBulkConfig(json)
+
+        assertNull(config.timeoutMs)
+    }
+
+    @Test
+    fun `parseConfigWithZeroTimeout returns null`() {
+        val json = """
+            {
+                "timeout": 0,
+                "run": {
+                    "cmd1": "ping -c 1 example.com"
+                }
+            }
+        """.trimIndent()
+
+        val config = parseBulkConfig(json)
+
+        assertNull(config.timeoutMs)
+    }
+
+    @Test
+    fun `parseConfigWithNegativeTimeout returns null`() {
+        val json = """
+            {
+                "timeout": -10,
+                "run": {
+                    "cmd1": "ping -c 1 example.com"
+                }
+            }
+        """.trimIndent()
+
+        val config = parseBulkConfig(json)
+
+        assertNull(config.timeoutMs)
+    }
+
+    @Test
+    fun `extractCommandTimeoutWithValidValueReturnsMs`() {
+        assertEquals(10_000L, BulkConfigParser.extractCommandTimeout("ping -c 4 -t 10 google.com"))
+        assertEquals(30_000L, BulkConfigParser.extractCommandTimeout("dig @1.1.1.1 -t 30 example.com"))
+        assertEquals(5_000L, BulkConfigParser.extractCommandTimeout("port-scan -p 80 -t 5 host"))
+    }
+
+    @Test
+    fun `extractCommandTimeoutWithNoTFlagReturnsNull`() {
+        assertNull(BulkConfigParser.extractCommandTimeout("ping -c 4 google.com"))
+        assertNull(BulkConfigParser.extractCommandTimeout("device-info"))
+    }
+
+    @Test
+    fun `extractCommandTimeoutWithZeroOrNegativeReturnsNull`() {
+        assertNull(BulkConfigParser.extractCommandTimeout("ping -c 4 -t 0 google.com"))
+        assertNull(BulkConfigParser.extractCommandTimeout("ping -c 4 -t -5 google.com"))
+    }
+
+    @Test
+    fun `extractCommandTimeoutWithNonNumericReturnsNull`() {
+        assertNull(BulkConfigParser.extractCommandTimeout("ping -c 4 -t abc google.com"))
     }
 }

--- a/notes/20260426_bulk-action_timeout-walkthrough.md
+++ b/notes/20260426_bulk-action_timeout-walkthrough.md
@@ -1,0 +1,155 @@
+# Bulk Actions: `-t` Timeout Support — Walkthrough
+
+> **Date:** 2026-04-26
+> **Scope:** `BulkActionsRepository.kt` — per-command `-t N` timeout parsing and semantics across all pseudo-commands.
+
+---
+
+## Global Mechanism
+
+Every bulk command supports an **optional per-command timeout** via the `-t N` flag in the command string.
+
+### How it works (two layers)
+
+1. **`extractCommandTimeout(cmd: String)`** — scans the command for `-t N`, returns `N * 1000L` milliseconds.
+   - `N` must be a positive integer. `0`, negative, or non-numeric values are ignored.
+   - `-t` can appear **anywhere** in the command string (before or after the hostname/target).
+
+2. **`executeCommands()`** — for each command:
+   ```kotlin
+   val commandTimeoutMs = extractCommandTimeout(cmd) ?: defaultTimeoutMs
+   // defaultTimeoutMs = config-level "timeout" field, or 30_000L (30s)
+   ```
+   The coroutine-level `withTimeoutOrNull(commandTimeoutMs)` wraps the entire command execution. If the command exceeds this timeout, it returns `BulkCommandTimeout`.
+
+### Hostname parsing fix (2026-04-26)
+
+Prior to this fix, the host was resolved with `parts.lastOrNull { !it.startsWith("-") }`, which broke when `-t` appeared **after** the hostname:
+
+| Command | Before (broken) | After (fixed) |
+|---|---|-:--|
+| `ping -c 1 google.com -t 10` | host = `"10"` ❌ | host = `"google.com"` ✅ |
+| `ping -c 1 -t 10 google.com` | host = `"google.com"` ✅ | host = `"google.com"` ✅ |
+
+The fix iterates through arguments, skipping flag-value pairs, and stops at the first non-flag token.
+
+---
+
+## Per-Command Behavior
+
+### `ping`
+
+| Aspect | Detail |
+|---|---|
+| **`-t` meaning** | Per-packet wait time in **seconds**, passed to the underlying ping binary as `-W N`. |
+| **Coroutine timeout** | Also set to `-t N` seconds (same value). |
+| **Default count** | 4 packets (if `-c` omitted). |
+| **Default timeout** | No per-packet `-W` (uses OS default). |
+| **Example** | `ping -c 3 -t 5 google.com` → 3 packets, wait 5s per packet, coroutine timeout 5s. |
+
+### `dig`
+
+| Aspect | Detail |
+|---|---|
+| **`-t` meaning** | **Not parsed** as a special flag. `-t` is consumed only by the global `extractCommandTimeout()` for the coroutine timeout. |
+| **Coroutine timeout** | Set to `-t N` milliseconds if present. |
+| **DNS server** | Parsed from `@server` argument; defaults to `8.8.8.8`. |
+| **Example** | `dig @1.1.1.1 example.com -t 15` → coroutine timeout 15s, DNS query to Cloudflare. |
+
+### `ntp`
+
+| Aspect | Detail |
+|---|---|
+| **`-t` meaning** | **Not parsed** as a special flag. Only the global coroutine timeout applies. |
+| **Coroutine timeout** | Set to `-t N` milliseconds if present. |
+| **Pool** | Parsed from `parts[1]`; defaults to `pool.ntp.org`. |
+| **Example** | `ntp pool.ntp.org -t 10` → coroutine timeout 10s, NTP query to pool.ntp.org. |
+
+### `port-scan`
+
+| Aspect | Detail |
+|---|---|
+| **`-t` meaning** | **Connection timeout per port** in **seconds**, multiplied by 1000 → milliseconds for `Socket.connect()`. |
+| **Coroutine timeout** | Also set to `-t N` milliseconds (same value). |
+| **Default** | 2000ms per port if `-t` omitted. |
+| **Host parsing** | Host is the first non-flag token after `-p ports` (or after `-t N` if present). |
+| **Example** | `port-scan -p 80,443 -t 3 google.com` → 3s connect timeout per port, coroutine timeout 3s. |
+
+### `checkcert`
+
+| Aspect | Detail |
+|---|---|
+| **`-t` meaning** | **Not passed** to the HTTPS cert I/O. Only the global coroutine timeout applies. |
+| **Coroutine timeout** | Set to `-t N` milliseconds if present. |
+| **Port** | Parsed from `-p N`; defaults to `443`. |
+| **Host parsing** | If `-t` is between `-p` and host, skips it: `checkcert -p 443 -t 5 google.com` → host = `"google.com"`. |
+| **Example** | `checkcert -p 443 -t 5 google.com` → coroutine timeout 5s, cert check on google.com:443. |
+
+### `device-info`
+
+| Aspect | Detail |
+|---|---|
+| **`-t` meaning** | **Ignored.** No timeout parameter accepted. |
+| **Coroutine timeout** | Falls back to config-level `timeout` or 30s default. |
+| **Usage** | `device-info` (no arguments). |
+
+### `tracert`
+
+| Aspect | Detail |
+|---|---|
+| **`-t` meaning** | **Max hops** (TTL probe limit), **not** a timeout. Defaults to 30 if omitted. |
+| **Coroutine timeout** | Set to `-t N` milliseconds if present (conflicts with hop semantics — see note below). |
+| **Internal ping** | Each hop uses `ping -c 1 -t <TTL> -W 2 <host>` internally. |
+| **⚠️ Semantic conflict** | If user writes `tracert google.com -t 10`, `-t` is interpreted as **10 hops** (for the traceroute logic) **and** 10s coroutine timeout. This is usually fine but can be confusing. |
+| **Example** | `tracert google.com -t 20` → probe up to 20 hops, coroutine timeout 20s. |
+
+### `google-timesync`
+
+| Aspect | Detail |
+|---|---|
+| **`-t` meaning** | **Ignored.** No timeout parameter accepted. |
+| **Coroutine timeout** | Falls back to config-level `timeout` or 30s default. |
+| **Usage** | `google-timesync` (no arguments). |
+
+### `lan-scan`
+
+| Aspect | Detail |
+|---|---|
+| **`-t` meaning** | **Ignored.** No timeout parameter accepted. |
+| **Coroutine timeout** | Fallsback to config-level `timeout` or 30s default. |
+| **Usage** | `lan-scan` (no arguments). |
+
+---
+
+## Config-Level Timeout
+
+The bulk config JSON supports a top-level `"timeout"` field (in **seconds**):
+
+```json
+{
+  "timeout": 42,
+  "run": {
+    "ping_google": "ping -c 1 google.com -t 10"
+  }
+}
+```
+
+- `"timeout": 42` → default 42s for all commands **that don't have their own `-t`**.
+- Per-command `-t` **overrides** the config-level timeout.
+- If neither exists, defaults to **30 seconds**.
+
+---
+
+## Summary Table
+
+| Pseudo-command | `-t` parsed? | `-t` unit | `-t` scope | Coroutine timeout affected? |
+|---|---:|---|---|---:|
+| `ping` | ✅ | seconds | Per-packet `-W` + coroutine | ✅ |
+| `dig` | ✅ (coroutine only) | ms (×1000) | Coroutine only | ✅ |
+| `ntp` | ✅ (coroutine only) | ms (×1000) | Coroutine only | ✅ |
+| `port-scan` | ✅ | seconds | Per-port connect + coroutine | ✅ |
+| `checkcert` | ✅ (coroutine only) | ms (×1000) | Coroutine only | ✅ |
+| `device-info` | ❌ | — | — | ❌ |
+| `tracert` | ✅ (as max hops) | hop count | Max hops + coroutine | ✅ (conflicts) |
+| `google-timesync` | ❌ | — | — | ❌ |
+| `lan-scan` | ❌ | — | — | ❌ |

--- a/notes/20260426_bulk-action_timeout_implementation-plan.md
+++ b/notes/20260426_bulk-action_timeout_implementation-plan.md
@@ -1,0 +1,284 @@
+# Implementation Plan: Bulk Actions `-t` (timeout) Argument
+
+**Date:** 2026-04-26
+**Status:** Planned
+
+---
+
+## Goal
+
+Add a global `timeout` field (alias `-t`) to the Bulk Actions JSON config that sets a **per-command timeout** (in seconds). This lets users control how long each individual command is allowed to run before being cancelled, overriding the default 30-second per-command timeout in `executeCommands()`.
+
+---
+
+## Design Decisions
+
+1. **Global per-config timeout** — A single `timeout` field at the root of the JSON config applies to every command. This is simpler than per-command timeouts and matches the existing pattern (`output-file` is also global).
+2. **Unit: seconds (user-friendly)** — Users specify timeout in seconds (e.g., `"timeout": 60`). Internally converted to milliseconds.
+3. **Default: 30s** — If `timeout` is absent or zero/negative, fall back to the existing 30-second default.
+4. **Applied at execution level** — The timeout is passed to `executeCommands()` and used to parameterize `withTimeoutOrNull()` instead of the hardcoded 30_000.
+
+### Commands that benefit from `-t`
+
+| Command | Default behavior | `-t` effect |
+|---|---|---|
+| `ping` | Runs until `-c` count completes (can hang) | Cancels after timeout |
+| `dig` | Uses `DigRepository` internal timeout | Overrides with shorter/longer |
+| `ntp` | Uses `NtpRepository` internal timeout | Overrides with shorter/longer |
+| `port-scan` | 2000ms per port (hardcoded in loop) | Cancels entire scan early |
+| `checkcert` | Uses `HttpsCertRepository` internal timeout | Overrides with shorter/longer |
+| `tracert` | `-W 2` per hop, up to 30 hops | Cancels entire trace early |
+| `google-timesync` | Uses `GoogleTimeSyncRepository` internal timeout | Overrides with shorter/longer |
+| `lan-scan` | Per-host ping timeout (repo internal) | Cancels entire scan early |
+| `device-info` | Local (instant) | No practical effect |
+
+---
+
+## Files to Modify
+
+### 1. `BulkConfig` data class (`BulkActionsRepository.kt`)
+
+**Change:** Add `timeoutMs: Long?` field.
+
+```kotlin
+data class BulkConfig(
+    val outputFile: String?,
+    val commands: Map<String, String>,
+    val timeoutMs: Long?,  // NEW
+)
+```
+
+### 2. `BulkConfigParser.parse()` (`BulkActionsRepository.kt`)
+
+**Change:** Extract optional `"timeout"` field from JSON, convert seconds → milliseconds.
+
+```kotlin
+// After extracting outputFile, before extracting run:
+val timeoutMs = runCatching {
+    val seconds = root.optLong("timeout", 0L)
+    if (seconds == null || seconds <= 0) null
+    else seconds * 1000L
+}.getOrNull()
+
+// Pass timeoutMs to BulkConfig constructor
+return BulkConfig(outputFile, commands, timeoutMs)
+```
+
+### 3. `BulkActionsRepository.executeCommands()` (`BulkActionsRepository.kt`)
+
+**Change:** Accept `configTimeoutMs` parameter and use it in `withTimeoutOrNull()`.
+
+```kotlin
+suspend fun executeCommands(
+    config: BulkConfig,
+    cancellationToken: AtomicBoolean = AtomicBoolean(false),
+    onProgress: ((BulkProgress) -> Unit)? = null,
+): List<BulkCommandResult> {
+    val results = mutableListOf<BulkCommandResult>()
+    val commands = config.commands.toList()
+    val total = commands.size
+    // Determine per-command timeout: config timeout or default 30s
+    val commandTimeoutMs = config.timeoutMs ?: 30_000L
+
+    commands.forEachIndexed { index, (name, cmd) ->
+        if (cancellationToken.get()) return results
+
+        onProgress?.invoke(BulkProgress(index, total, name, cmd))
+
+        val result = withTimeoutOrNull(commandTimeoutMs) {
+            executeSingleCommand(name, cmd)
+        }
+
+        val finalResult = result ?: BulkCommandTimeout(name, cmd)
+        results.add(finalResult)
+    }
+
+    return results
+}
+```
+
+### 4. `BulkActionsViewModel.kt`
+
+**Change:** Pass `config.timeoutMs` through to the UI state and repository.
+
+#### 4a. Add to `BulkUiState`
+
+```kotlin
+data class BulkUiState(
+    // ... existing fields ...
+    val configTimeoutMs: Long? = null,  // NEW
+    // ... existing fields ...
+)
+```
+
+#### 4b. In `onFileSelected()` / config loading
+
+```kotlin
+// After parsing config:
+val updatedState = state.copy(
+    // ... existing fields ...
+    configTimeoutMs = config.timeoutMs,  // NEW
+)
+```
+
+#### 4c. In `onRunClicked()` / execution
+
+```kotlin
+// When calling the repository:
+val results = bulkRepo.executeCommands(
+    config = parsedConfig,
+    cancellationToken = running,
+    onProgress = { progress -> /* ... */ }
+)
+// executeCommands reads config.timeoutMs internally, no extra param needed
+```
+
+### 5. `BulkActionsScreen.kt`
+
+**Change:** Display timeout in the config loaded summary card.
+
+In the "Config Loaded" card (where `commandCount` is shown), add a line:
+
+```kotlin
+if (state.configTimeoutMs != null) {
+    Text("Timeout: ${state.configTimeoutMs / 1000}s per command")
+}
+```
+
+Or combine into the summary:
+
+```kotlin
+val timeoutText = state.configTimeoutMs?.let { " · ${it / 1000}s timeout" } ?: ""
+Text("${state.commandCount} commands$timeoutText")
+```
+
+### 6. Tests
+
+#### 6a. `BulkConfigParserTest.kt` — Add timeout parsing tests
+
+```kotlin
+@Test
+fun `parseConfigWithTimeout returns timeoutMs`() {
+    val json = """
+        {
+            "timeout": 60,
+            "run": {
+                "cmd1": "ping -c 1 example.com"
+            }
+        }
+    """.trimIndent()
+    val config = parseBulkConfig(json)
+    assertEquals(60_000L, config.timeoutMs)
+}
+
+@Test
+fun `parseConfigWithoutTimeout returns null`() {
+    val json = """
+        {
+            "run": {
+                "cmd1": "ping -c 1 example.com"
+            }
+        }
+    """.trimIndent()
+    val config = parseBulkConfig(json)
+    assertNull(config.timeoutMs)
+}
+
+@Test
+fun `parseConfigWithZeroTimeout returns null (fallback to default)`() {
+    val json = """
+        {
+            "timeout": 0,
+            "run": {
+                "cmd1": "ping -c 1 example.com"
+            }
+        }
+    """.trimIndent()
+    val config = parseBulkConfig(json)
+    assertNull(config.timeoutMs)
+}
+
+@Test
+fun `parseConfigWithNegativeTimeout returns null (fallback to default)`() {
+    val json = """
+        {
+            "timeout": -10,
+            "run": {
+                "cmd1": "ping -c 1 example.com"
+            }
+        }
+    """.trimIndent()
+    val config = parseBulkConfig(json)
+    assertNull(config.timeoutMs)
+}
+```
+
+#### 6b. `BulkActionsViewModelTest.kt` — Add timeout flow test
+
+```kotlin
+@Test
+fun `onFileSelected with timeout sets configTimeoutMs`() {
+    val json = """
+        {
+            "timeout": 45,
+            "run": {
+                "cmd1": "ping -c 1 example.com"
+            }
+        }
+    """.trimIndent()
+    // ... set up file mock ...
+    viewModel.onFileSelected(testUri, "test.json")
+    assertThat(viewModel.state.value.configTimeoutMs).isEqualTo(45_000L)
+}
+```
+
+### 7. Example config file (`notes/config-files_bulk-actions/`)
+
+Create a new example:
+
+```json
+{
+  "output-file": "~/Downloads/bulk-with-timeout.txt",
+  "timeout": 60,
+  "run": {
+    "ping_google": "ping -c 4 google.com",
+    "dig_cloudflare": "dig @1.1.1.1 example.com",
+    "tracert_google": "tracert google.com",
+    "port_scan_google": "port-scan -p 80,443 google.com",
+    "ntp_pool": "ntp pool.ntp.org"
+  }
+}
+```
+
+---
+
+## Execution Order
+
+1. **Data model changes** — `BulkConfig` + `BulkConfigParser` (files 1-2)
+2. **Repository changes** — `executeCommands()` timeout parameterization (file 3)
+3. **ViewModel changes** — `BulkUiState` + state propagation (file 4)
+4. **UI changes** — Display timeout in config summary (file 5)
+5. **Tests** — Parser tests + ViewModel test (file 6)
+6. **Example config** — New JSON example (file 7)
+
+---
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|---|---|
+| Backward compatibility: existing configs without `timeout` | Parser returns `null`, falls back to 30s default — no behavior change |
+| `optLong()` throws on non-numeric values | Wrapped in `runCatching`, returns `null` on failure → falls back to 30s |
+| Very large timeout values (overflow) | `optLong()` max is `Long.MAX_VALUE` (~292 years); no practical concern |
+| `withTimeoutOrNull` interaction with `CancellationException` | Existing code already handles this — no change needed |
+
+---
+
+## Verification Steps
+
+1. Run `./gradlew test` — all existing tests pass + new timeout tests pass
+2. Load a config with `"timeout": 60` — verify `configTimeoutMs` shows in UI
+3. Load a config without `timeout` — verify default 30s behavior (no UI change)
+4. Load a config with `"timeout": 0` — verify fallback to 30s default
+5. Execute a slow command with `"timeout": 5` — verify command is cancelled after 5s
+6. Build debug APK — `./gradlew assembleDebug` — no compile errors

--- a/notes/2060426_test-with-robolectric.md
+++ b/notes/2060426_test-with-robolectric.md
@@ -1,0 +1,323 @@
+# Robolectric Testing Analysis for ntp_dig_ping_more
+
+**Date:** 2026-04-26  
+**Author:** Qwen Code Analysis
+
+---
+
+## 1. Executive Summary
+
+**Recommendation: Do NOT migrate to Robolectric.**
+
+Your current test architecture (JUnit 4 + MockK + Kotlin Coroutines Test, pure JVM) is well-suited to this project's needs. The 12 test files with ~188 test methods provide fast, reliable coverage of business logic. Robolectric would add maintenance burden without meaningful benefit for your use case.
+
+**What to do instead:** Keep current tests as-is. If UI testing is needed in the future, add **Android instrumentation tests** (Espresso + Compose Test) for Compose screens, not Robolectric.
+
+---
+
+## 2. Current Test Architecture
+
+### Stack
+
+| Component | Version | Purpose |
+|---|---|---|
+| JUnit 4 | 4.13.2 | Test framework |
+| MockK | 1.13.12 | Dependency mocking |
+| kotlinx-coroutines-test | 1.8.1 | Coroutine test dispatcher control |
+| JaCoCo | 0.8.12 | Code coverage |
+
+### Coverage
+
+| Layer | Status | Details |
+|---|---|---|
+| **ViewModels** | ✅ Complete | All 9 ViewModels tested (122+ tests) |
+| **Repositories** | ✅ Partial | IP conversion, parsing logic fully tested |
+| **History Stores** | ✅ Complete | All 8 history formats tested (30+ tests) |
+| **Bulk Actions** | ✅ Complete | Parser + ViewModel tested (23 tests) |
+| **Compose UI** | ❌ Not started | Dependencies declared but no tests written |
+| **PingViewModel** | ❌ Pending | Requires Runtime.exec mocking |
+
+### Known Issues
+
+- **11 failing tests** in `LanScannerViewModelTest` and `DeviceInfoViewModelTest` due to complex coroutine lifecycle issues in `init` blocks
+- Root cause: ViewModels accept `Context` in constructors; test dispatchers cannot be injected
+- Fix: Refactor ViewModels to accept `TestDispatcher` parameters
+
+---
+
+## 3. Robolectric Overview
+
+### What It Is
+
+Robolectric is a JVM-based testing framework that **simulates the Android framework** at the bytecode level. Tests run inside a regular JVM (no emulator or device needed) while getting real Android objects (Context, Resources, View, etc.).
+
+### How It Works
+
+- **Bytecode instrumentation:** Robolectric replaces Android SDK stubs with real implementations at runtime
+- **Resource simulation:** Loads real `res/` resources (layouts, strings, drawables) into the test JVM
+- **System service simulation:** Mocks Android system services (LocationManager, WifiManager, etc.)
+- **Test isolation:** Each test runs in a sandboxed Android environment with precise configuration control
+
+### Current Version
+
+**Robolectric 4.16** (latest stable)
+
+### Setup Requirements
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.robolectric:robolectric:4.16")
+}
+
+android {
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true  // Load real res/ files
+        }
+    }
+}
+```
+
+```kotlin
+// Test class
+@RunWith(RobolectricTestRunner::class)
+class MyScreenTest {
+    @Test
+    fun testSomething() {
+        val activity = Robolectric.buildActivity(YourActivity::class.java).create().get()
+        // Real Android objects, real resources
+    }
+}
+```
+
+---
+
+## 4. Analysis: Is Robolectric a Good Idea for This Project?
+
+### 4.1 Benefits
+
+| Benefit | Relevance to This Project |
+|---|---|
+| **No mocking needed for Android APIs** | Moderate — your ViewModels use Coroutines + sealed results, not raw Android APIs |
+| **Real resource loading** | Low — your app uses Compose (no XML layouts or resource-heavy screens) |
+| **More realistic Android behavior** | Low — your business logic is network diagnostics, not UI or system services |
+| **Black-box testing style** | Moderate — tests behavior rather than implementation |
+| **Faster than emulator tests** | Low — your JVM tests already run in seconds |
+| **CI-friendly** | Low — your current tests already run on CI via `./gradlew test` |
+
+### 4.2 Risks
+
+| Risk | Severity | Details |
+|---|---|---|
+| **API divergence** | Medium | Robolectric's simulation may not match real device behavior exactly, leading to false positives |
+| **Maintenance burden** | High | New framework to learn, new test paradigm, potential upgrade costs |
+| **Test flakiness** | Medium | Robolectric tests can be flaky due to SDK version differences, resource loading issues |
+| **Learning curve** | Medium | Your team uses MockK + Coroutines Test effectively; Robolectric is a different paradigm |
+| **Compose testing limitations** | High | Robolectric + Compose testing is less mature than Espresso + Compose Test |
+| **Build complexity** | Medium | Requires `includeAndroidResources = true`, potentially `@Config` annotations, SDK version management |
+
+### 4.3 Maintenance Effort
+
+| Task | Estimated Effort |
+|---|---|
+| Add Robolectric dependency + config | 30 min |
+| Refactor ViewModels to accept TestDispatcher (fix 11 failures) | 2-3 hours |
+| Write new Robolectric tests for 8 screens | 2-3 days |
+| Ongoing maintenance (upgrades, SDK version pinning) | 2-4 hours/month |
+| **Total initial effort** | **~1 week** |
+| **Total ongoing effort** | **2-4 hours/month** |
+
+---
+
+## 5. Answer: Shall We Remove Current MockK + JaCoCo Tests?
+
+### Recommendation: **NO — Keep current tests.**
+
+### Why Your Current Tests Are Good
+
+1. **Fast feedback:** JVM tests run in seconds, not minutes
+2. **Precise control:** MockK + TestDispatcher gives you exact control over every dependency
+3. **Right layer:** Your ViewModels are thin — they expose StateFlow and delegate to repositories. Testing at this layer with mocks is the correct approach
+4. **No Android dependency:** Tests don't need Android SDK at all — they run on any JVM
+5. **Well-architected:** 12 files, ~188 tests, consistent patterns across all ViewModels
+6. **JaCoCo coverage:** Real code coverage metrics are already in place
+
+### What Robolectric Would Add
+
+- Real Android Context/Resource objects (not needed — you use Compose, not XML)
+- Real system service behavior (not needed — your app doesn't use many system services)
+- Real resource loading (not needed — Compose doesn't depend on resources)
+
+### What Robolectric Would NOT Add
+
+- Better ViewModel testing (MockK is ideal for this)
+- Better repository testing (your repos are Coroutines + sealed results — pure functions)
+- Better UI testing (Espresso + Compose Test is the right choice for Compose UI)
+
+### Verdict
+
+**Your current test architecture is the right choice for this project.** Robolectric is designed for apps that:
+- Use XML layouts and resource-heavy screens
+- Test Android framework behavior directly
+- Need to test Activities/Fragments with real Android lifecycle
+
+Your app uses **Compose (no XML), sealed-result repositories, and thin ViewModels** — exactly the architecture that MockK + JVM tests excel at.
+
+---
+
+## 6. What Would Be Needed to Implement Robolectric (If Chosen)
+
+### Step 1: Add Dependencies
+
+```kotlin
+// app/build.gradle.kts
+dependencies {
+    testImplementation("org.robolectric:robolectric:4.16")
+}
+```
+
+### Step 2: Configure Android Block
+
+```kotlin
+// app/build.gradle.kts
+android {
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
+}
+```
+
+### Step 3: Fix 11 Known Failing Tests
+
+Refactor `LanScannerViewModel` and `DeviceInfoViewModel` to accept `TestDispatcher` parameters:
+
+```kotlin
+// Before (current — causes 11 failures)
+class LanScannerViewModel(context: Context) {
+    init {
+        viewModelScope.launch { /* complex init logic */ }
+    }
+}
+
+// After (fixable with tests)
+class LanScannerViewModel(
+    context: Context,
+    private val testDispatcher: TestDispatcher? = null  // injected in tests
+) {
+    init {
+        val dispatcher = testDispatcher ?: StandardTestDispatcher()
+        viewModelScope.launch(dispatcher) { /* same init logic */ }
+    }
+}
+```
+
+### Step 4: Write Robolectric Tests for Screens
+
+For each Compose screen, you would need:
+
+```kotlin
+@RunWith(RobolectricTestRunner::class)
+class NtpScreenTest {
+    @Test
+    fun testNtpCheckFlow() {
+        val activity = Robolectric.buildActivity(MainActivity::class.java).create().get()
+        // Test Compose UI with real Android Context
+        // Use Robolectric's Shadow classes for system services
+    }
+}
+```
+
+**Estimated effort per screen:** 2-4 hours (learning curve + writing + debugging)
+
+### Step 5: Manage SDK Versions
+
+```kotlin
+// robolectric.properties or @Config annotation
+@Config(sdk = [26, 28, 30, 33, 34])
+class MyTest {
+    // Tests run against multiple Android SDK versions
+}
+```
+
+### Step 6: Handle Resource Conflicts
+
+Your app uses `commons-net`, `dnsjava`, and other libraries with `META-INF` files. Robolectric may need additional configuration to handle these in tests.
+
+---
+
+## 7. Final Recommendation
+
+### Keep Current Tests + Add Instrumentation Tests (Not Robolectric)
+
+| Testing Layer | Approach | Why |
+|---|---|---|
+| **Business logic** (ViewModels, repos, parsing) | **Keep MockK + JVM** | Fast, precise, right tool for the job |
+| **Compose UI** (screens, navigation) | **Espresso + Compose Test** (instrumentation) | Mature, reliable, real device behavior |
+| **Network I/O** (NTP, DNS, HTTP) | **Keep MockK** | Repos return sealed results — perfect for mocking |
+| **Real device behavior** (permissions, runtime) | **Instrumentation tests** | Only real devices/emulators can test these |
+
+### Priority Order for Future Testing
+
+1. **Fix the 11 known failing tests** — Refactor ViewModels to accept `TestDispatcher`
+2. **Add PingViewModel tests** — Mock `Runtime.exec` or refactor to use a repository
+3. **Add Compose UI tests** (optional) — Use `createComposeRule()` for critical user flows
+4. **Measure coverage** — Run `./gradlew jacocoUnitTestReport` and review gaps
+
+### What NOT to Do
+
+- **Do NOT migrate to Robolectric** — wrong architecture match, high cost, low benefit
+- **Do NOT remove current tests** — they are well-architected and serve the right layer
+- **Do NOT write instrumentation tests for everything** — keep JVM tests for business logic
+
+---
+
+## 8. Appendix: Comparison Table
+
+| Criterion | MockK + JVM (current) | Robolectric | Espresso + Instrumentation |
+|---|---|---|---|
+| **Speed** | ⚡ Very fast (seconds) | ⚡ Fast (seconds) | 🐢 Slow (minutes) |
+| **Android SDK needed** | ❌ No | ✅ Yes (simulated) | ✅ Yes (real device/emulator) |
+| **Mocking needed** | ✅ Yes (dependencies) | ❌ No (real objects) | ❌ No (real objects) |
+| **Real Android behavior** | ❌ No | ⚠️ Partial | ✅ Yes |
+| **Compose testing** | ❌ Not supported | ⚠️ Limited | ✅ First-class |
+| **Coroutines testing** | ✅ Excellent | ⚠️ Works | ✅ Works |
+| **Network I/O testing** | ✅ Perfect (mock repo) | ✅ Works | ⚠️ Needs real network |
+| **Learning curve** | Low (your team knows it) | Medium | Medium |
+| **Maintenance** | Low | Medium-High | Medium |
+| **CI integration** | ✅ Trivial | ✅ Easy | ⚠️ Needs emulator |
+| **Test reliability** | ✅ Very reliable | ⚠️ Can be flaky | ✅ Reliable |
+| **Best for** | Business logic, ViewModels | Activities, resources, Android APIs | UI flows, real device behavior |
+
+---
+
+## 9. Appendix: Current Test File Inventory
+
+| File | Tests | Layer | Framework |
+|---|---|---|---|
+| `NtpViewModelTest.kt` | 14 | ViewModel | MockK + JUnit4 |
+| `GoogleTimeSyncViewModelTest.kt` | 14 | ViewModel | MockK + JUnit4 |
+| `PortScannerViewModelTest.kt` | 12 | ViewModel | MockK + JUnit4 |
+| `DigViewModelTest.kt` | 14 | ViewModel | MockK + JUnit4 |
+| `TracerouteViewModelTest.kt` | 16 | ViewModel | MockK + JUnit4 |
+| `LanScannerViewModelTest.kt` | 21 | ViewModel | MockK + JUnit4 |
+| `HttpsCertViewModelTest.kt` | 28 | ViewModel | MockK + JUnit4 |
+| `DeviceInfoViewModelTest.kt` | 13 | ViewModel | MockK + JUnit4 |
+| `HistoryStoreParsingTest.kt` | 30+ | Parsing | JUnit4 |
+| `LanScannerRepositoryTest.kt` | 18 | Pure functions | JUnit4 |
+| `BulkConfigParserTest.kt` | 17 | Parsing | JUnit4 |
+| `BulkActionsViewModelTest.kt` | 6 | ViewModel | MockK + JUnit4 |
+| **Total** | **~188** | | |
+
+---
+
+## 10. Key Takeaways
+
+1. **Your current tests are excellent** — well-architected, fast, and cover the right layer
+2. **Robolectric is the wrong tool** for a Compose-based app with thin ViewModels
+3. **If you need UI testing**, use Espresso + Compose Test (instrumentation), not Robolectric
+4. **Fix the 11 known failures** first — they are fixable with a small ViewModel refactor
+5. **Robolectric's sweet spot** is XML-layout apps testing Activities/Fragment lifecycle — not your use case

--- a/notes/config-files_bulk-actions/blkacts-ping-only.json
+++ b/notes/config-files_bulk-actions/blkacts-ping-only.json
@@ -1,0 +1,11 @@
+{
+  "output-file": "~/Downloads/bulk-with-timeout.txt",
+  "timeout": 42,
+  "run": {
+    "ping_google": "ping -c 1 google.com -t 10",
+    "ping_google2": "ping -c 1 -t 10 google.com",
+    "ping_google_noto": "ping -c 1 google.com",
+    "ping_cybernews": "ping -c 4 cybernews.com",
+    "ping_mobilutils": "ping -c 2 mobilutils.eu -t 1"
+  }
+}

--- a/notes/config-files_bulk-actions/bulkactions-complete-with-timeout.json
+++ b/notes/config-files_bulk-actions/bulkactions-complete-with-timeout.json
@@ -1,0 +1,32 @@
+{
+  "output-file": "~/Downloads/bulkactions-complete-with-timeout.txt",
+  "timeout": 60,
+  "run": {
+    "1_ping_basic": "ping -c 4 -t 10 google.com",
+    "2_ping_custom_count": "ping -c 10 -t 15 example.com",
+    "3_ping_local": "ping -c 2 -t 5 10.0.0.1",
+
+    "4_dig_default": "dig @8.8.8.8 -t 10 google.com",
+    "5_dig_custom_server": "dig @1.1.1.1 -t 10 example.com",
+    "6_dig_cybernews": "dig @1.1.1.1 -t 10 cybernews.com",
+
+    "7_ntp_default": "ntp -t 15 pool.ntp.org",
+    "8_ntp_regional": "ntp -t 15 fr.pool.ntp.org",
+
+    "9_port_scan_specific": "port-scan -p 80,443 -t 10 google.com",
+    "10_port_scan_range": "port-scan -p 22-8080 -t 30 example.com",
+    "11_port_scan_single": "port-scan -p 80 -t 10 mobilutils.com",
+
+    "12_checkcert_default": "checkcert -p 443 -t 10 google.com",
+    "13_checkcert_custom_port": "checkcert -p 8443 -t 10 proxy.phttp.com",
+
+    "14_device_info": "device-info",
+
+    "15_tracert_google": "tracert -t 20 google.com",
+    "16_tracert_cloudflare": "tracert -t 20 1.1.1.1",
+
+    "17_google_timesync": "google-timesync -t 10",
+
+    "18_lan_scan": "lan-scan -t 30"
+  }
+}

--- a/notes/config-files_bulk-actions/bulkactions-with-timeout.json
+++ b/notes/config-files_bulk-actions/bulkactions-with-timeout.json
@@ -1,0 +1,11 @@
+{
+  "output-file": "~/Downloads/bulk-with-timeout.txt",
+  "timeout": 42,
+  "run": {
+    "ping_google": "ping -c 4 google.com -t 10",
+    "dig_cloudflare": "dig @1.1.1.1 example.com",
+    "tracert_google": "tracert google.com",
+    "port_scan_google": "port-scan -p 80,443 google.com -t 10",
+    "ntp_pool": "ntp pool.ntp.org"
+  }
+}


### PR DESCRIPTION
> **Date:** 2026-04-26
> **Scope:** `BulkActionsRepository.kt` — per-command `-t N` timeout parsing and semantics across all pseudo-commands.

---

## Global Mechanism

Every bulk command supports an **optional per-command timeout** via the `-t N` flag in the command string.

### How it works (two layers)

1. **`extractCommandTimeout(cmd: String)`** — scans the command for `-t N`, returns `N * 1000L` milliseconds.
   - `N` must be a positive integer. `0`, negative, or non-numeric values are ignored.
   - `-t` can appear **anywhere** in the command string (before or after the hostname/target).

2. **`executeCommands()`** — for each command:
   ```kotlin
   val commandTimeoutMs = extractCommandTimeout(cmd) ?: defaultTimeoutMs
   // defaultTimeoutMs = config-level "timeout" field, or 30_000L (30s)
   ```
   The coroutine-level `withTimeoutOrNull(commandTimeoutMs)` wraps the entire command execution. If the command exceeds this timeout, it returns `BulkCommandTimeout`.

### Hostname parsing fix (2026-04-26)

Prior to this fix, the host was resolved with `parts.lastOrNull { !it.startsWith("-") }`, which broke when `-t` appeared **after** the hostname:

| Command | Before (broken) | After (fixed) |
|---|---|-:--|
| `ping -c 1 google.com -t 10` | host = `"10"` ❌ | host = `"google.com"` ✅ |
| `ping -c 1 -t 10 google.com` | host = `"google.com"` ✅ | host = `"google.com"` ✅ |

The fix iterates through arguments, skipping flag-value pairs, and stops at the first non-flag token.

---

## Per-Command Behavior

### `ping`

| Aspect | Detail |
|---|---|
| **`-t` meaning** | Per-packet wait time in **seconds**, passed to the underlying ping binary as `-W N`. |
| **Coroutine timeout** | Also set to `-t N` seconds (same value). |
| **Default count** | 4 packets (if `-c` omitted). |
| **Default timeout** | No per-packet `-W` (uses OS default). |
| **Example** | `ping -c 3 -t 5 google.com` → 3 packets, wait 5s per packet, coroutine timeout 5s. |

### `dig`

| Aspect | Detail |
|---|---|
| **`-t` meaning** | **Not parsed** as a special flag. `-t` is consumed only by the global `extractCommandTimeout()` for the coroutine timeout. |
| **Coroutine timeout** | Set to `-t N` milliseconds if present. |
| **DNS server** | Parsed from `@server` argument; defaults to `8.8.8.8`. |
| **Example** | `dig @1.1.1.1 example.com -t 15` → coroutine timeout 15s, DNS query to Cloudflare. |

### `ntp`

| Aspect | Detail |
|---|---|
| **`-t` meaning** | **Not parsed** as a special flag. Only the global coroutine timeout applies. |
| **Coroutine timeout** | Set to `-t N` milliseconds if present. |
| **Pool** | Parsed from `parts[1]`; defaults to `pool.ntp.org`. |
| **Example** | `ntp pool.ntp.org -t 10` → coroutine timeout 10s, NTP query to pool.ntp.org. |

### `port-scan`

| Aspect | Detail |
|---|---|
| **`-t` meaning** | **Connection timeout per port** in **seconds**, multiplied by 1000 → milliseconds for `Socket.connect()`. |
| **Coroutine timeout** | Also set to `-t N` milliseconds (same value). |
| **Default** | 2000ms per port if `-t` omitted. |
| **Host parsing** | Host is the first non-flag token after `-p ports` (or after `-t N` if present). |
| **Example** | `port-scan -p 80,443 -t 3 google.com` → 3s connect timeout per port, coroutine timeout 3s. |

### `checkcert`

| Aspect | Detail |
|---|---|
| **`-t` meaning** | **Not passed** to the HTTPS cert I/O. Only the global coroutine timeout applies. |
| **Coroutine timeout** | Set to `-t N` milliseconds if present. |
| **Port** | Parsed from `-p N`; defaults to `443`. |
| **Host parsing** | If `-t` is between `-p` and host, skips it: `checkcert -p 443 -t 5 google.com` → host = `"google.com"`. |
| **Example** | `checkcert -p 443 -t 5 google.com` → coroutine timeout 5s, cert check on google.com:443. |

### `device-info`

| Aspect | Detail |
|---|---|
| **`-t` meaning** | **Ignored.** No timeout parameter accepted. |
| **Coroutine timeout** | Falls back to config-level `timeout` or 30s default. |
| **Usage** | `device-info` (no arguments). |

### `tracert`

| Aspect | Detail |
|---|---|
| **`-t` meaning** | **Max hops** (TTL probe limit), **not** a timeout. Defaults to 30 if omitted. |
| **Coroutine timeout** | Set to `-t N` milliseconds if present (conflicts with hop semantics — see note below). |
| **Internal ping** | Each hop uses `ping -c 1 -t <TTL> -W 2 <host>` internally. |
| **⚠️ Semantic conflict** | If user writes `tracert google.com -t 10`, `-t` is interpreted as **10 hops** (for the traceroute logic) **and** 10s coroutine timeout. This is usually fine but can be confusing. |
| **Example** | `tracert google.com -t 20` → probe up to 20 hops, coroutine timeout 20s. |

### `google-timesync`

| Aspect | Detail |
|---|---|
| **`-t` meaning** | **Ignored.** No timeout parameter accepted. |
| **Coroutine timeout** | Falls back to config-level `timeout` or 30s default. |
| **Usage** | `google-timesync` (no arguments). |

### `lan-scan`

| Aspect | Detail |
|---|---|
| **`-t` meaning** | **Ignored.** No timeout parameter accepted. |
| **Coroutine timeout** | Fallsback to config-level `timeout` or 30s default. |
| **Usage** | `lan-scan` (no arguments). |

---

## Config-Level Timeout

The bulk config JSON supports a top-level `"timeout"` field (in **seconds**):

```json
{
  "timeout": 42,
  "run": {
    "ping_google": "ping -c 1 google.com -t 10"
  }
}
```

- `"timeout": 42` → default 42s for all commands **that don't have their own `-t`**.
- Per-command `-t` **overrides** the config-level timeout.
- If neither exists, defaults to **30 seconds**.

---

## Summary Table

| Pseudo-command | `-t` parsed? | `-t` unit | `-t` scope | Coroutine timeout affected? |
|---|---:|---|---|---:|
| `ping` | ✅ | seconds | Per-packet `-W` + coroutine | ✅ |
| `dig` | ✅ (coroutine only) | ms (×1000) | Coroutine only | ✅ |
| `ntp` | ✅ (coroutine only) | ms (×1000) | Coroutine only | ✅ |
| `port-scan` | ✅ | seconds | Per-port connect + coroutine | ✅ |
| `checkcert` | ✅ (coroutine only) | ms (×1000) | Coroutine only | ✅ |
| `device-info` | ❌ | — | — | ❌ |
| `tracert` | ✅ (as max hops) | hop count | Max hops + coroutine | ✅ (conflicts) |
| `google-timesync` | ❌ | — | — | ❌ |
| `lan-scan` | ❌ | — | — | ❌ |
