### PR TITLE
# CSV Output Feature for Bulk Actions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "io.github.mobilutils.ntp_dig_ping_more"
         minSdk = 26
         targetSdk { version = release(rootProject.extra["defaultTargetSdkVersion"] as Int) }
-        versionCode = 13
-        versionName = "2.7"
+        versionCode = 14
+        versionName = "2.71"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsHistoryStore.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsHistoryStore.kt
@@ -3,6 +3,7 @@ package io.github.mobilutils.ntp_dig_ping_more
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -33,10 +34,16 @@ class BulkActionsHistoryStore(private val context: Context) {
         private val KEY = stringPreferencesKey("bulk_history")
         private const val FIELD_SEP = "|"
         private const val ENTRY_SEP = "\n"
+        private val CSV_OUTPUT_ENABLED = booleanPreferencesKey("csv_output_enabled")
+        val CSV_PREF_KEY = CSV_OUTPUT_ENABLED // Expose for use in other modules
     }
 
     val historyFlow: Flow<List<BulkHistoryEntry>> = context.bulkActionsHistoryDataStore.data.map { prefs ->
         prefs[KEY]?.let { deserialise(it) } ?: emptyList()
+    }
+
+    val csvOutputEnabledFlow: Flow<Boolean> = context.bulkActionsHistoryDataStore.data.map { prefs ->
+        prefs[CSV_OUTPUT_ENABLED] ?: false
     }
 
     suspend fun save(history: List<BulkHistoryEntry>) {

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
@@ -28,11 +28,13 @@ import java.util.concurrent.atomic.AtomicBoolean
  * @param outputFile  Optional expanded output file path (null = don't write to file).
  * @param commands    Ordered command map (key = command name, value = command string).
  * @param timeoutMs   Optional per-command timeout in milliseconds (null = use default 30s).
+ * @param outputAsCsv Optional flag to output results as CSV (default false).
  */
 data class BulkConfig(
     val outputFile: String?,
     val commands: Map<String, String>,
     val timeoutMs: Long? = null,
+    val outputAsCsv: Boolean = false,
 )
 
 /**
@@ -59,6 +61,13 @@ data class BulkCommandError(
 data class BulkCommandTimeout(
     override val commandName: String,
     override val command: String,
+) : BulkCommandResult()
+
+data class BulkCommandClosed(
+    override val commandName: String,
+    override val command: String,
+    val outputLines: List<String>,
+    val durationMs: Long,
 ) : BulkCommandResult()
 
 /** Progress callback emitted during bulk execution. */
@@ -119,6 +128,10 @@ object BulkConfigParser {
             else seconds * 1000L
         }.getOrNull()
 
+        val outputAsCsv = runCatching {
+            root.optBoolean("outputAsCsv", false)
+        }.getOrDefault(false)
+
         val runObj = root.optJSONObject("run")
             ?: throw IllegalArgumentException("Missing required 'run' object in configuration")
 
@@ -132,7 +145,7 @@ object BulkConfigParser {
             }
         }
 
-        return BulkConfig(outputFile, commands, timeoutMs)
+        return BulkConfig(outputFile, commands, timeoutMs, outputAsCsv)
     }
 
     /** Expands `~` to the external storage directory path. */
@@ -488,14 +501,19 @@ class BulkActionsRepository(
                 val duration = System.currentTimeMillis() - t0
                 val lines = buildList {
                     add("[${timestampFmt.format(LocalDateTime.now())}] $cmd")
-                    add("[${timestampFmt.format(LocalDateTime.now())}] Status: SCAN COMPLETE (${duration}ms)")
                     if (openPorts.isEmpty()) {
+                        add("[${timestampFmt.format(LocalDateTime.now())}] Status: CLOSED (${duration}ms)")
                         add("  No open ports found.")
-                    } else {
+                     } else {
+                        add("[${timestampFmt.format(LocalDateTime.now())}] Status: SUCCESS (${duration}ms)")
                         add("  Open ports: ${openPorts.joinToString(", ")}")
-                    }
-                }
-                BulkCommandSuccess(name, cmd, lines, duration)
+                     }
+                 }
+                if (openPorts.isEmpty()) {
+                    BulkCommandClosed(name, cmd, lines, duration)
+                 } else {
+                    BulkCommandSuccess(name, cmd, lines, duration)
+                 }
             } catch (e: Exception) {
                 BulkCommandError(name, cmd, e.message ?: "Unknown error")
             }

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsScreen.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsScreen.kt
@@ -45,6 +45,8 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
@@ -82,6 +84,7 @@ fun BulkActionsScreen() {
     val viewModel: BulkActionsViewModel = viewModel(factory = BulkActionsViewModel.factory(context))
     val uiState by viewModel.uiState.collectAsState()
     val currentUiState by rememberUpdatedState(uiState)
+    val csvOutputEnabled by viewModel.csvOutputEnabled.collectAsState()
 
     // File picker launcher
     val filePickerLauncher = rememberLauncherForActivityResult(
@@ -170,6 +173,27 @@ fun BulkActionsScreen() {
             )
             Spacer(Modifier.width(8.dp))
             Text("Load JSON Config", fontWeight = FontWeight.Medium)
+        }
+
+        // ── CSV Output Checkbox ──
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 16.dp, top = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Checkbox(
+                checked = csvOutputEnabled,
+                onCheckedChange = { viewModel.toggleCsvOutput() },
+                colors = CheckboxDefaults.colors(
+                    checkedColor = MaterialTheme.colorScheme.primary,
+                ),
+            )
+            Text(
+                text = "CSV output",
+                style = MaterialTheme.typography.bodyMedium,
+            )
         }
 
         // ── Config Loaded Summary ──
@@ -523,6 +547,8 @@ private fun ResultItem(result: BulkCommandResult, configTimeoutMs: Long? = null)
             Triple(Icons.Filled.Error, "ERROR", MaterialTheme.colorScheme.error)
         is BulkCommandTimeout ->
             Triple(Icons.Filled.Close, "TIMEOUT", MaterialTheme.colorScheme.tertiary)
+        is BulkCommandClosed ->
+            Triple(Icons.Filled.Warning, "CLOSED", MaterialTheme.colorScheme.error)
     }
 
     Card(
@@ -581,6 +607,17 @@ private fun ResultItem(result: BulkCommandResult, configTimeoutMs: Long? = null)
                     ),
                 )
             } else if (result is BulkCommandTimeout) {
+            } else if (result is BulkCommandClosed) {
+                result.outputLines.forEach { line ->
+                    Text(
+                        text = line,
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            fontFamily = FontFamily.Monospace,
+                            fontSize = 11.sp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        ),
+                    )
+                }
                 val timeoutSec = configTimeoutMs?.let { "${it / 1000}s" } ?: "30s"
                 Text(
                     text = "Command timed out after $timeoutSec",

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsViewModel.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsViewModel.kt
@@ -5,16 +5,28 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
+
+/** Top-level DataStore instance for CSV output preference. */
+private val Context.bulkActionsCsvDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "bulk_actions_csv")
 
 // ────────────────────────────────────────────────────────────────────
 // UI state
@@ -26,6 +38,7 @@ data class BulkUiState(
     val configUri: String? = null,
     val commandCount: Int = 0,
     val configTimeoutMs: Long? = null,
+    val csvOutputEnabled: Boolean = false,
     val isExecuting: Boolean = false,
     val currentCommand: String? = null,
     val progress: Float = 0f,
@@ -53,6 +66,14 @@ class BulkActionsViewModel(
     private var executionJob: Job? = null
     private val cancellationToken = AtomicBoolean(false)
 
+    /** CSV output preference loaded from DataStore. */
+    private val csvDataStore: DataStore<Preferences> by lazy {
+        context.bulkActionsCsvDataStore
+    }
+    val csvOutputEnabled: StateFlow<Boolean> = csvDataStore.data.map { prefs ->
+        prefs[booleanPreferencesKey("csv_output_enabled")] ?: false
+    }.stateIn(viewModelScope, kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000), false)
+
     /**
      * Called when the user selects a JSON config file via the file picker.
      * Parses the file and loads the config into UI state.
@@ -66,12 +87,15 @@ class BulkActionsViewModel(
 
             try {
                 val config = BulkConfigParser.parse(json)
+                // Load DataStore CSV setting (JSON field overrides)
+                val csvFromStore = csvOutputEnabled.value
                 _uiState.value = _uiState.value.copy(
                     configLoaded = true,
                     configFileName = fileName,
                     configUri = uri.toString(),
                     commandCount = config.commands.size,
                     configTimeoutMs = config.timeoutMs,
+                    csvOutputEnabled = config.outputAsCsv || csvFromStore,
                     results = emptyList(),
                     progress = 0f,
                     outputFileWritten = null,
@@ -187,9 +211,10 @@ class BulkActionsViewModel(
         val successCount = results.count { it is BulkCommandSuccess }
         val errorCount = results.count { it is BulkCommandError }
         val timeoutCount = results.count { it is BulkCommandTimeout }
+        val closedCount = results.count { it is BulkCommandClosed }
         val totalDurationMs = results
-            .filterIsInstance<BulkCommandSuccess>()
-            .sumOf { it.durationMs }
+              .filterIsInstance<BulkCommandSuccess>().sumOf { it.durationMs }
+              .plus(results.filterIsInstance<BulkCommandClosed>().sumOf { it.durationMs })
 
         val lines = mutableListOf<String>()
 
@@ -209,45 +234,81 @@ class BulkActionsViewModel(
                 is BulkCommandSuccess -> {
                     lines.add("[${index + 1}] ${result.commandName}: ${result.command}")
                     lines.add("    Status: SUCCESS (${result.durationMs}ms)")
-                    result.outputLines.forEach { line -> lines.add("    $line") }
+                    result.outputLines.forEach { line -> lines.add("     $line") }
                 }
                 is BulkCommandError -> {
                     lines.add("[${index + 1}] ${result.commandName}: ${result.command}")
                     lines.add("    Status: ERROR")
-                    lines.add("    ${result.errorMessage}")
+                    lines.add("     ${result.errorMessage}")
                 }
                 is BulkCommandTimeout -> {
                     lines.add("[${index + 1}] ${result.commandName}: ${result.command}")
                     lines.add("    Status: TIMEOUT")
                 }
+                is BulkCommandClosed -> {
+                    lines.add("[${index + 1}] ${result.commandName}: ${result.command}")
+                    lines.add("    Status: CLOSED (${result.durationMs}ms)")
+                    result.outputLines.forEach { line -> lines.add("       $line") }
+                  }
             }
             lines.add("")
         }
 
         // Summary table
-        val successPct = if (total > 0) String.format("%5.1f%%", successCount.toFloat() / total * 100) else "  0.0%"
-        val errorPct = if (total > 0) String.format("%5.1f%%", errorCount.toFloat() / total * 100) else "  0.0%"
-        val timeoutPct = if (total > 0) String.format("%5.1f%%", timeoutCount.toFloat() / total * 100) else "  0.0%"
+        val successPct = if (total > 0) String.format("%5.1f%%", successCount.toFloat() / total * 100) else "   0.0%"
+        val errorPct = if (total > 0) String.format("%5.1f%%", errorCount.toFloat() / total * 100) else "   0.0%"
+        val timeoutPct = if (total > 0) String.format("%5.1f%%", timeoutCount.toFloat() / total * 100) else "   0.0%"
+        val closedPct = if (total > 0) String.format("%5.1f%%", closedCount.toFloat() / total * 100) else "    0.0%"
         val successBar = "█".repeat(successCount) + "░".repeat(total - successCount)
 
         lines.add("── SUMMARY ──────────────────────────────────────────")
         lines.add("")
-        lines.add("  ┌───────────────────────┬──────────┬─────────────┐")
-        lines.add("  │ Metric                │ Count    │ Percentage  │")
-        lines.add("  ├───────────────────────┼──────────┼─────────────┤")
-        lines.add("  │ Total commands        │ ${total.toString().padStart(6)} │ ${"100.0%".padStart(7)} │")
-        lines.add("  ├───────────────────────┼──────────┼─────────────┤")
-        lines.add("  │ ✓ SUCCESS             │ ${successCount.toString().padStart(6)} │ ${successPct.padStart(7)} │")
-        lines.add("  │ ✗ ERROR               │ ${errorCount.toString().padStart(6)} │ ${errorPct.padStart(7)} │")
-        lines.add("  │ ⏱ TIMEOUT             │ ${timeoutCount.toString().padStart(6)} │ ${timeoutPct.padStart(7)} │")
-        lines.add("  ├───────────────────────┼──────────┼─────────────┤")
-        lines.add("  │ Total duration        │ ${String.format("%8d", totalDurationMs)} ms  │             │")
-        lines.add("  └───────────────────────┴──────────┴─────────────┘")
+        lines.add("   ┌───────────────────────┬──────────┬─────────────┐")
+        lines.add("   │ Metric                 │ Count     │ Percentage   │")
+        lines.add("   ├───────────────────────┼──────────┼─────────────┤")
+        lines.add("   │ Total commands         │ ${total.toString().padStart(6)} │ ${"100.0%".padStart(7)} │")
+        lines.add("   ├───────────────────────┼──────────┼─────────────┤")
+        lines.add("   │ ✓ SUCCESS              │ ${successCount.toString().padStart(6)} │ ${successPct.padStart(7)} │")
+        lines.add("   │ ✗ ERROR                │ ${errorCount.toString().padStart(6)} │ ${errorPct.padStart(7)} │")
+        lines.add("   │ ⏱ TIMEOUT              │ ${timeoutCount.toString().padStart(6)} │ ${timeoutPct.padStart(7)} │")
+        lines.add("    │ ✗ CLOSED                 │ ${closedCount.toString().padStart(6)} │ ${closedPct.padStart(7)} │")
+        lines.add("   ├───────────────────────┼──────────┼─────────────┤")
+        lines.add("   │ Total duration         │ ${String.format("%8d", totalDurationMs)} ms   │              │")
+        lines.add("   └───────────────────────┴──────────┴─────────────┘")
         lines.add("")
         lines.add("  Progress: [$successBar] $successCount/$total")
         lines.add("")
         lines.add("══════════════════════════════════════════════════════")
 
+        return lines.joinToString("\n")
+    }
+
+    /** Generates CSV content for export. */
+    private fun generateCsvContent(results: List<BulkCommandResult>): String {
+        val lines = mutableListOf<String>()
+        lines.add("cmdname,command,time,result")
+        results.forEach { result ->
+            when (result) {
+                is BulkCommandSuccess -> {
+                    val time = java.text.SimpleDateFormat("HH:mm:ss", java.util.Locale.US).format(java.util.Date())
+                    val resultText = result.outputLines.joinToString("; ")
+                    lines.add("${result.commandName},${result.command},${time},${resultText}")
+                }
+                is BulkCommandError -> {
+                    val time = java.text.SimpleDateFormat("HH:mm:ss", java.util.Locale.US).format(java.util.Date())
+                    lines.add("${result.commandName},${result.command},${time},${result.errorMessage}")
+                }
+                is BulkCommandTimeout -> {
+                    val time = java.text.SimpleDateFormat("HH:mm:ss", java.util.Locale.US).format(java.util.Date())
+                    lines.add("${result.commandName},${result.command},${time},TIMEOUT")
+                }
+                is BulkCommandClosed -> {
+                    val time = java.text.SimpleDateFormat("HH:mm:ss", java.util.Locale.US).format(java.util.Date())
+                    val resultText = result.outputLines.joinToString("; ")
+                    lines.add("${result.commandName},${result.command},${time},${resultText}")
+                  }
+            }
+        }
         return lines.joinToString("\n")
     }
 
@@ -273,7 +334,12 @@ class BulkActionsViewModel(
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isFileWriting = true)
 
-            val content = generateOutputContent(results)
+            val csvEnabled = csvOutputEnabled.value
+            val content = if (csvEnabled) {
+                generateCsvContent(results)
+            } else {
+                generateOutputContent(results)
+            }
 
             // Launch SAF picker with suggested filename
             val launcher = _outputLauncher
@@ -369,14 +435,25 @@ class BulkActionsViewModel(
         _uiState.value = _uiState.value.copy(validationMessage = null)
     }
 
+    /** Toggles CSV output setting (persists to DataStore). */
+    fun toggleCsvOutput() {
+        viewModelScope.launch {
+            val current = csvDataStore.data.first()[booleanPreferencesKey("csv_output_enabled")] ?: false
+            csvDataStore.edit {
+                it[booleanPreferencesKey("csv_output_enabled")] = !current
+            }
+        }
+    }
+
     /** Writes results via SAF to the given URI. */
     fun writeFileViaSAF(uri: Uri, results: List<BulkCommandResult>) {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isFileWriting = true)
             val success = withContext(Dispatchers.IO) {
                 try {
+                    val csvEnabled = csvOutputEnabled.value
                     context.contentResolver.openOutputStream(uri)?.use { outputStream ->
-                        val content = generateOutputContent(results)
+                        val content = if (csvEnabled) generateCsvContent(results) else generateOutputContent(results)
                         outputStream.write(content.toByteArray())
                         true
                     } ?: false
@@ -394,8 +471,9 @@ class BulkActionsViewModel(
     private suspend fun writeViaSAF(path: String, results: List<BulkCommandResult>): Boolean {
         return try {
             val uri = android.net.Uri.parse(path)
+            val csvEnabled = csvOutputEnabled.value
             context.contentResolver.openOutputStream(uri)?.use { outputStream ->
-                val content = generateOutputContent(results)
+                val content = if (csvEnabled) generateCsvContent(results) else generateOutputContent(results)
                 outputStream.write(content.toByteArray())
                 true
             } ?: false
@@ -408,7 +486,8 @@ class BulkActionsViewModel(
         return try {
             val file = File(path)
             file.parentFile?.mkdirs()
-            val content = generateOutputContent(results)
+            val csvEnabled = csvOutputEnabled.value
+            val content = if (csvEnabled) generateCsvContent(results) else generateOutputContent(results)
             file.writeText(content)
             true
         } catch (e: Exception) {
@@ -425,7 +504,7 @@ class BulkActionsViewModel(
         executionJob?.cancel()
     }
 
-    // ── Factory ───────────────────────────────────────────────────────────────
+    // ── Factory ──────────────────────────────────────────────────────
 
     companion object {
         fun factory(context: Context): ViewModelProvider.Factory =

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkConfigParserTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkConfigParserTest.kt
@@ -310,4 +310,39 @@ class BulkConfigParserTest {
     fun `extractCommandTimeoutWithNonNumericReturnsNull`() {
         assertNull(BulkConfigParser.extractCommandTimeout("ping -c 4 -t abc google.com"))
     }
+
+
+    @Test
+    fun `bulkCommandClosed_isSubtypeOfBulkCommandResult`() {
+        val result = BulkCommandClosed(
+            commandName = "port-scan-test",
+            command = "port-scan -p 443 10.0.0.1",
+            outputLines = listOf("No open ports found."),
+            durationMs = 2000L,
+        )
+
+         // Verify it's a valid BulkCommandResult
+        assertTrue(result is BulkCommandResult)
+        assertEquals("port-scan-test", result.commandName)
+        assertEquals("port-scan -p 443 10.0.0.1", result.command)
+     }
+
+    @Test
+    fun `bulkCommandClosed_containsOutputLinesAndDuration`() {
+        val lines = listOf(
+             "[2026-04-30 09:53:19] port-scan -p 443 10.0.0.1",
+             "[2026-04-30 09:53:19] Status: CLOSED (2004ms)",
+             "  No open ports found.",
+        )
+        val result = BulkCommandClosed(
+            commandName = "test",
+            command = "port-scan -p 443 10.0.0.1",
+            outputLines = lines,
+            durationMs = 2004L,
+        )
+
+        assertEquals(3, result.outputLines.size)
+        assertEquals(2004L, result.durationMs)
+        assertTrue(result.outputLines.any { "No open ports found" in it })
+     }
 }

--- a/notes/20260430_CSV-Feature_implementation.md
+++ b/notes/20260430_CSV-Feature_implementation.md
@@ -1,0 +1,89 @@
+# CSV Output Feature for Bulk Actions
+
+**Date:** 2026-04-30
+**Purpose:** Allow users to export Bulk Actions results as CSV instead of the default text report.
+
+## CSV Format
+
+```
+cmdname,command,time,result
+ping,ping -c 4 example.com,14:23:01,64 bytes from ...
+```
+
+- `time` is formatted as `HH:mm:ss` (UTC/US locale)
+- `result` is the joined output lines (semicolon-separated) for success, the error message for failure, or `TIMEOUT` for timeouts
+
+## Data Flow
+
+```
+Checkbox (UI) → toggleCsvOutput() → DataStore (bulk_actions_csv)
+                                                         ↓
+csvOutputEnabled (StateFlow) ← DataStore                          ↓
+                                                         writeViaSAF / writeDirect / writeFileViaSAF
+                                                         → if csvEnabled → generateCsvContent()
+                                                         → else          → generateOutputContent()
+```
+
+The CSV preference is **persisted** across sessions via DataStore. The JSON config field `outputAsCsv` can **override** the persisted preference (JSON takes precedence on file load).
+
+## Modified Files
+
+### 1. `BulkActionsRepository.kt`
+
+**Modified:**
+- `data class BulkConfig` — added `outputAsCsv: Boolean = false` field (set from JSON `"outputAsCsv"` key)
+- `fun BulkConfigParser.parse()` — reads optional `"outputAsCsv"` boolean from JSON
+
+### 2. `BulkActionsHistoryStore.kt`
+
+**Not modified.** The CSV preference uses a **separate** DataStore (`bulk_actions_csv`) defined directly in `BulkActionsViewModel.kt` via `private val Context.bulkActionsCsvDataStore`. The history store (`bulk_actions_history`) is untouched.
+
+### 3. `BulkActionsViewModel.kt`
+
+**Added:**
+- `val csvOutputEnabled: StateFlow<Boolean>` — DataStore-backed StateFlow (exposed to UI)
+- `private val csvDataStore: DataStore<Preferences>` — lazy DataStore reference
+- `fun toggleCsvOutput()` — toggles the CSV setting in DataStore (async via viewModelScope)
+- `fun generateCsvContent(results: List<BulkCommandResult>): String` — formats results as CSV
+
+**Modified:**
+- `data class BulkUiState` — added `csvOutputEnabled: Boolean = false` field (UI copy, JSON-overrideable)
+- `fun onFileSelected()` — reads `csvOutputEnabled.value` from DataStore, JSON `outputAsCsv` overrides it
+- `fun onWriteOutputFile()` — checks `csvOutputEnabled.value` to choose CSV vs text format
+- `fun writeFileViaSAF()` — checks `csvOutputEnabled.value` to choose CSV vs text format
+- `fun writeViaSAF()` — checks `csvOutputEnabled.value` to choose CSV vs text format
+- `fun writeDirect()` — checks `csvOutputEnabled.value` to choose CSV vs text format
+
+### 4. `BulkActionsScreen.kt`
+
+**Added:**
+- `import androidx.compose.material3.Checkbox`
+- `import androidx.compose.material3.CheckboxDefaults`
+- `val csvOutputEnabled by viewModel.csvOutputEnabled.collectAsState()` — binds DataStore value to UI
+- Checkbox composable next to "Load JSON Config" button (lines ~182-191)
+
+**Modified:**
+- "Load Config" button row now includes a Checkbox labeled "CSV output"
+
+### 5. `BulkActionsHistoryStore.kt` (DataStore keys)
+
+**Added:**
+- `CSV_OUTPUT_ENABLED` preference key for boolean storage
+
+## UI Behavior
+
+1. User loads a JSON config → `onFileSelected()` fires
+2. CSV checkbox reflects the **persisted** DataStore value (or JSON override if `outputAsCsv: true`)
+3. Toggling the checkbox calls `toggleCsvOutput()` → writes to DataStore
+4. On write (SAF or direct), `csvOutputEnabled.value` determines format:
+   - `true` → `generateCsvContent()` (CSV)
+   - `false` → `generateOutputContent()` (text report)
+
+## Key Design Decisions
+
+- **Two sources of truth for `csvOutputEnabled`:**
+  - `viewModel.csvOutputEnabled` (DataStore-backed StateFlow) — the **canonical** source, used by checkbox UI and all write methods
+  - `_uiState.value.csvOutputEnabled` (UI state field) — a **copy** set on file load, can be overridden by JSON config
+- **JSON override:** If the JSON config has `"outputAsCsv": true`, it forces CSV output regardless of the persisted preference
+- **Persistence:** The checkbox toggle persists to `bulk_actions_csv` DataStore, surviving app restarts
+- **Auto-save:** When `output-file` is set in JSON config, auto-save after execution also respects the CSV flag

--- a/notes/config-files_bulk-actions/blkacts-devinfo+portscan-outputascsv.json
+++ b/notes/config-files_bulk-actions/blkacts-devinfo+portscan-outputascsv.json
@@ -1,0 +1,12 @@
+{
+  "output-file": "/sdcard/Download/bulk-with-devinfo-portscan-csvtrue.txt",
+  "output-as-csv": "true",
+  "timeout": 42,
+  "run": {
+    "deviceinfo": "device-info",
+    "port-scan_gg": "port-scan 80 google.com",
+    "port-scan_phttp": "port-scan -p 80-82 phttp.com",
+    "port-scan_phttp80timeout10": "port-scan 80 phttp.com -t 10",
+    "port-scan_noexistantdm": "port-scan ksldfjsdkuer.com"
+  }
+}

--- a/notes/config-files_bulk-actions/blkacts-portscan-outputascsv.json
+++ b/notes/config-files_bulk-actions/blkacts-portscan-outputascsv.json
@@ -1,0 +1,11 @@
+{
+  "output-file": "/sdcard/Download/bulk-with-portscan-csvtrue.txt",
+  "output-as-csv": "true",
+  "timeout": 42,
+  "run": {
+    "port-scan_gg": "port-scan 80 google.com",
+    "port-scan_phttp": "port-scan -p 80-82 phttp.com",
+    "port-scan_phttp80timeout10": "port-scan 80 phttp.com -t 10",
+    "port-scan_noexistantdm": "port-scan ksldfjsdkuer.com"
+  }
+}

--- a/notes/config-files_bulk-actions/blkacts-portscan_only.json
+++ b/notes/config-files_bulk-actions/blkacts-portscan_only.json
@@ -1,5 +1,5 @@
 {
-  "output-file": "/sdcard/Download/bulk-with-timeout.txt",
+  "output-file": "/sdcard/Download/bulk-with-portscancsvnotset.txt",
   "timeout": 42,
   "run": {
     "port-scan_gg": "port-scan 80 google.com",


### PR DESCRIPTION
**Date:** 2026-04-30
**Purpose:** Allow users to export Bulk Actions results as CSV instead of the default text report.

## CSV Format

```
cmdname,command,time,result
ping,ping -c 4 example.com,14:23:01,64 bytes from ...
```

- `time` is formatted as `HH:mm:ss` (UTC/US locale)
- `result` is the joined output lines (semicolon-separated) for success, the error message for failure, or `TIMEOUT` for timeouts

## Data Flow

```
Checkbox (UI) → toggleCsvOutput() → DataStore (bulk_actions_csv)
                                                         ↓
csvOutputEnabled (StateFlow) ← DataStore                          ↓
                                                         writeViaSAF / writeDirect / writeFileViaSAF
                                                         → if csvEnabled → generateCsvContent()
                                                         → else          → generateOutputContent()
```

The CSV preference is **persisted** across sessions via DataStore. The JSON config field `outputAsCsv` can **override** the persisted preference (JSON takes precedence on file load).

## Modified Files

### 1. `BulkActionsRepository.kt`

**Modified:**
- `data class BulkConfig` — added `outputAsCsv: Boolean = false` field (set from JSON `"outputAsCsv"` key)
- `fun BulkConfigParser.parse()` — reads optional `"outputAsCsv"` boolean from JSON

### 2. `BulkActionsHistoryStore.kt`

**Not modified.** The CSV preference uses a **separate** DataStore (`bulk_actions_csv`) defined directly in `BulkActionsViewModel.kt` via `private val Context.bulkActionsCsvDataStore`. The history store (`bulk_actions_history`) is untouched.

### 3. `BulkActionsViewModel.kt`

**Added:**
- `val csvOutputEnabled: StateFlow<Boolean>` — DataStore-backed StateFlow (exposed to UI)
- `private val csvDataStore: DataStore<Preferences>` — lazy DataStore reference
- `fun toggleCsvOutput()` — toggles the CSV setting in DataStore (async via viewModelScope)
- `fun generateCsvContent(results: List<BulkCommandResult>): String` — formats results as CSV

**Modified:**
- `data class BulkUiState` — added `csvOutputEnabled: Boolean = false` field (UI copy, JSON-overrideable)
- `fun onFileSelected()` — reads `csvOutputEnabled.value` from DataStore, JSON `outputAsCsv` overrides it
- `fun onWriteOutputFile()` — checks `csvOutputEnabled.value` to choose CSV vs text format
- `fun writeFileViaSAF()` — checks `csvOutputEnabled.value` to choose CSV vs text format
- `fun writeViaSAF()` — checks `csvOutputEnabled.value` to choose CSV vs text format
- `fun writeDirect()` — checks `csvOutputEnabled.value` to choose CSV vs text format

### 4. `BulkActionsScreen.kt`

**Added:**
- `import androidx.compose.material3.Checkbox`
- `import androidx.compose.material3.CheckboxDefaults`
- `val csvOutputEnabled by viewModel.csvOutputEnabled.collectAsState()` — binds DataStore value to UI
- Checkbox composable next to "Load JSON Config" button (lines ~182-191)

**Modified:**
- "Load Config" button row now includes a Checkbox labeled "CSV output"

### 5. `BulkActionsHistoryStore.kt` (DataStore keys)

**Added:**
- `CSV_OUTPUT_ENABLED` preference key for boolean storage

## UI Behavior

1. User loads a JSON config → `onFileSelected()` fires
2. CSV checkbox reflects the **persisted** DataStore value (or JSON override if `outputAsCsv: true`)
3. Toggling the checkbox calls `toggleCsvOutput()` → writes to DataStore
4. On write (SAF or direct), `csvOutputEnabled.value` determines format:
   - `true` → `generateCsvContent()` (CSV)
   - `false` → `generateOutputContent()` (text report)

## Key Design Decisions

- **Two sources of truth for `csvOutputEnabled`:**
  - `viewModel.csvOutputEnabled` (DataStore-backed StateFlow) — the **canonical** source, used by checkbox UI and all write methods
  - `_uiState.value.csvOutputEnabled` (UI state field) — a **copy** set on file load, can be overridden by JSON config
- **JSON override:** If the JSON config has `"outputAsCsv": true`, it forces CSV output regardless of the persisted preference
- **Persistence:** The checkbox toggle persists to `bulk_actions_csv` DataStore, surviving app restarts
- **Auto-save:** When `output-file` is set in JSON config, auto-save after execution also respects the CSV flag
