### PR TITLE
# Walkthrough: Proxy PAC Settings Integration

### DIFF
--- a/QWEN.md
+++ b/QWEN.md
@@ -13,63 +13,72 @@
 - **LAN Scanner** — Subnet device discovery (IP, hostname, MAC, latency)
 - **Google Time Sync** — HTTP-based time sync with RTT/offset computation
 - **Device Info** — Read-only device identity, network, battery, storage, MDM status, CA certs
+- **HTTPS Cert Check** — Certificate inspection for hosts
 - **Bulk Actions** — Batch execution of diagnostic commands from a JSON config, with ADB automation support for headless/CI workflows
 
 ## Architecture
 
 | Layer | Technology |
 |---|---|
-| Language | Kotlin 2.2.10 |
-| UI | Jetpack Compose + Material 3 (BOM 2025.01.00) |
+| Language | Kotlin (via Kotlin Compose plugin) |
+| UI | Jetpack Compose + Material 3 |
 | Architecture | MVVM (ViewModel + StateFlow) |
-| Navigation | Jetpack Navigation Compose 2.8.9 |
+| Navigation | Jetpack Navigation Compose |
 | Concurrency | Kotlin Coroutines (`Dispatchers.IO`) |
 | Persistence | AndroidX DataStore Preferences (query history) |
 | Build | Gradle Kotlin DSL, AGP 9.2.0 |
 | Min SDK | 26 (Android 8.0) |
 | Compile SDK | 37 |
-| Target SDK | 35 (inferred from `defaultTargetSdkVersion`) |
 
 ### Key Dependencies
 - `commons-net:3.11.1` — NTP UDP client
 - `dnsjava:3.6.2` — DNS resolution
 - `androidx.datastore:preferences:1.1.1` — History persistence
 - `androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7` — ViewModel integration
+- `app.cash.quickjs:quickjs-android:0.9.2` — JS engine for PAC proxy evaluation (Telnet feature)
 - `junit:4.13.2`, `mockk:1.13.12`, `kotlinx-coroutines-test:1.8.1` — Testing
 
 ## Project Structure
 
 ```
 app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/
-├── MainActivity.kt               # NavHost, bottom navigation
+├── MainActivity.kt                 # NavHost, bottom navigation bar
+├── MoreToolsScreen.kt              # Overflow screen (Traceroute, Port Scanner, LAN Scanner, etc.)
+├── SettingsScreen.kt               # Settings UI + Proxy/PAC configuration screens
 ├── NtpScreen.kt, NtpViewModel.kt, NtpRepository.kt, NtpHistoryStore.kt
-├── DigScreen.kt, DigViewModel.kt, DigRepository.kt
+├── DigScreen.kt, DigViewModel.kt, DigRepository.kt, DigHistoryStore.kt
 ├── PingScreen.kt, PingViewModel.kt, PingHistoryStore.kt
 ├── TracerouteScreen.kt, TracerouteViewModel.kt, TracerouteHistoryStore.kt
 ├── PortScannerScreen.kt, PortScannerViewModel.kt, PortScannerHistoryStore.kt
 ├── LanScannerScreen.kt, LanScannerViewModel.kt, LanScannerRepository.kt, LanScannerHistoryStore.kt
-├── GoogleTimeSyncScreen.kt, GoogleTimeSyncViewModel.kt, GoogleTimeSyncRepository.kt
-├── DeviceInfo/
-│    ├── DeviceInfoScreen.kt
-│    ├── DeviceInfoViewModel.kt
-│    ├── DeviceInfoModels.kt
-│    └── SystemInfoRepository.kt
-├── MoreToolsScreen.kt            # Overflow: Traceroute, Port Scanner, LAN Scanner, Google Time Sync, Device Info
-├── HttpsCertScreen.kt, HttpsCertViewModel.kt, HttpsCertHistoryStore.kt
-└── ui/theme/                     # Material 3 colors, typography, theme
+├── GoogleTimeSyncScreen.kt, GoogleTimeSyncViewModel.kt, GoogleTimeSyncRepository.kt, GoogleTimeSyncHistoryStore.kt
+├── HttpsCertScreen.kt, HttpsCertViewModel.kt, HttpsCertRepository.kt, HttpsCertHistoryStore.kt
+├── BulkActionsScreen.kt, BulkActionsViewModel.kt, BulkActionsRepository.kt, BulkActionsHistoryStore.kt
+├── SettingsViewModel.kt              # Settings state management
+├── proxy/                            # PAC proxy resolution (QuickJS-based)
+│      └── ProxyResolver.kt          # PAC script evaluation for Telnet feature
+├── deviceinfo/
+│      ├── DeviceInfoScreen.kt
+│      ├── DeviceInfoViewModel.kt
+│      ├── DeviceInfoModels.kt
+│      └── SystemInfoRepository.kt
+└── ui/theme/                       # Material 3 colors, typography, theme
 
 app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/
-├── NtpViewModelTest.kt           (14 tests)
-├── DigViewModelTest.kt           (14 tests)
-├── PingViewModelTest.kt          (pending)
-├── TracerouteViewModelTest.kt    (16 tests)
-├── PortScannerViewModelTest.kt   (12 tests)
-├── LanScannerViewModelTest.kt    (21 tests)
-├── LanScannerRepositoryTest.kt   (18 tests)
+├── NtpViewModelTest.kt             (14 tests)
+├── DigViewModelTest.kt             (14 tests)
+├── TracerouteViewModelTest.kt      (16 tests)
+├── PortScannerViewModelTest.kt     (12 tests)
+├── LanScannerViewModelTest.kt      (21 tests)
+├── LanScannerRepositoryTest.kt     (18 tests)
 ├── GoogleTimeSyncViewModelTest.kt (14 tests)
-├── HttpsCertViewModelTest.kt     (28 tests)
+├── HttpsCertViewModelTest.kt       (28 tests)
+├── BulkActionsViewModelTest.kt
+├── BulkConfigParserTest.kt
+├── ProxyResolverTest.kt            # PAC proxy resolver tests
+├── SettingsViewModelTest.kt        # Settings UI state tests
 ├── deviceinfo/DeviceInfoViewModelTest.kt (13 tests)
-└── HistoryStoreParsingTest.kt    (30+ tests)
+└── HistoryStoreParsingTest.kt      (30+ tests)
 ```
 
 ## Building and Running
@@ -109,26 +118,33 @@ In Android Studio: open the project root → wait for Gradle sync → connect de
 
 - **MVVM pattern:** Each feature has a `*Screen.kt` (Compose UI), `*ViewModel.kt` (StateFlow state), and optionally `*Repository.kt` (network I/O) and `*HistoryStore.kt` (DataStore).
 - **Coroutine concurrency:** All network operations run on `Dispatchers.IO` via coroutines. Timeouts are applied per-operation.
-- **History persistence:** Each tool keeps the last 5 (or 10 for LAN scanner) entries in DataStore, persisted across app restarts.
+- **History persistence:** Each tool keeps the last 5–10 entries in DataStore, persisted across app restarts.
 - **Runtime permissions:** Location (`ACCESS_COARSE/FINE_LOCATION`) and phone state (`READ_PHONE_STATE`) are requested at runtime via `ActivityResultContracts`.
 - **Cleartext traffic:** `android:usesCleartextTraffic="true"` is set in `AndroidManifest.xml` for the Google Time Sync HTTP endpoint.
 - **Android 13+ (API 33):** `READ_EXTERNAL_STORAGE` is no longer grantable; Bulk Actions ADB automation pushes configs via `run-as` pipe and pulls results the same way.
-- **Build config:** Keystore is at `.keystore/my-release.keystore` (debug builds don't require it). ProGuard is disabled for release (`isMinifyEnabled = false`).
+- **Build config:** Keystore at `.keystore/my-release.keystore`. ProGuard disabled for release (`isMinifyEnabled = false`).
 - **Version catalog:** All dependency versions are in `gradle/libs.versions.toml`.
+- **Target SDK:** Set to 37 via `rootProject.extra["defaultTargetSdkVersion"]` in the root `build.gradle.kts`.
 
 ## Bulk Actions / ADB Automation
 
 The app supports headless batch execution via ADB intent extras (`--ez auto_run true`). See `README.md` for full ADB script documentation and common pitfalls. Bundled scripts:
 - `BULKACTIONS-ADB-SCRIPT.sh` — Mac/Linux/Unix
-- `BULKACTIONS-ADB-WINDOWS-SCRIPT.bat` — Windows (needs testing)
+- `BULKACTIONS-ADB-WINDOWS-SCRIPT.bat` — Windows
 
 ## Permissions Required
 
 ```xml
-INTERNET, ACCESS_NETWORK_STATE, ACCESS_WIFI_STATE  (normal — auto-granted)
-ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION        (dangerous — runtime request)
-READ_PHONE_STATE                                    (dangerous — runtime request)
+INTERNET, ACCESS_NETWORK_STATE, ACCESS_WIFI_STATE    (normal — auto-granted)
+ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION          (dangerous — runtime request)
+READ_PHONE_STATE                                      (dangerous — runtime request)
 ```
+
+## Version
+
+- **Name:** NTP DIG PING MORE
+- **Version:** 2.9 (release), 2.9-dev (debug)
+- **Version Code:** 20
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="notes/icon_ntp-dig-ping-more_macgiver.png" alt="App Icon" width="128" height="128">
 </p>
 
-A modern Android app for network diagnostics: **NTP reachability testing**, **DNS lookup (DIG)**, **Ping**, **Traceroute**, **Port Scanner**, **LAN Scanner**, **Google Time Sync**, and **Bulk Actions** (batch execute commands from a JSON config).
+A modern Android app for network diagnostics: **NTP reachability testing**, **DNS lookup (DIG)**, **Ping**, **Traceroute**, **Port Scanner**, **LAN Scanner**, **Google Time Sync**, **HTTPS Certificate Inspector**, and **Bulk Actions** (batch execute commands from a JSON config). Includes a global **Settings** screen with configurable operation timeouts and optional **Proxy PAC** routing.
 
 ## Visuals
 
@@ -99,6 +99,35 @@ connect.hostinger.com.   120  IN  A      34.120.137.41
 - Custom host field (defaults to `clients2.google.com`)
 - One-tap **Copy Offset** button for manual clock-adjustment workflows
 - Idle / Loading / Success / Error states survive rotation and config changes
+- Supports optional proxy routing when Proxy PAC is enabled in Settings
+
+### 🔒 HTTPS Certificate Inspector
+- Enter any hostname and port (defaults to `google.com:443`)
+- Performs a real TLS handshake and extracts the peer's leaf certificate
+- Displays:
+  - Subject / Issuer distinguished names (CN, O, OU, C)
+  - Validity period (Not Before / Not After) with days-until-expiry
+  - Validity status: ✅ Valid · ⚠️ Expiring Soon · ❌ Expired
+  - Serial number, SHA-256 and SHA-1 fingerprints (tap to copy)
+  - Subject Alternative Names (SANs)
+  - Key algorithm, key size, signature algorithm, chain depth
+- Detects untrusted chains and self-signed certificates without bypassing security
+- Last 5 inspected hosts kept as clickable history (persisted across app restarts)
+- Supports SSL tunneling through HTTP CONNECT when Proxy PAC is enabled
+
+### ⚙️ Settings
+- **Operation Timeout** — global timeout (1–60 s) applied to all network tools
+  - Changes saved immediately on valid input; reverts on focus-loss if invalid
+- **Proxy PAC Configuration** — app-level proxy override (independent of system proxy)
+  - Toggle proxy routing on/off
+  - PAC URL input with URL format validation (http/https only)
+  - PAC scripts evaluated with a lightweight JavaScript engine (QuickJS)
+  - PAC results cached with 5-minute TTL for performance
+  - Supports `PROXY`, `SOCKS`, and `DIRECT` directives with fallback chains
+  - **"Test Proxy/PAC"** button sends a HEAD request through the resolved proxy and reports latency
+  - Last test result and timestamp persisted across app restarts
+  - Applied to Google Time Sync (HTTP) and HTTPS Certificate Inspector (SSL CONNECT tunnel)
+  - All failures fall back silently to DIRECT — proxy issues never block normal usage
 
 ### 📱 Device Info
 - Comprehensive read-only view of device identity, network, battery, and security
@@ -232,7 +261,8 @@ See [notes/20260501_BulkActions-ADB-Script-fixed.md](notes/20260501_BulkActions-
 | Concurrency | Kotlin Coroutines (`Dispatchers.IO`) |
 | NTP | Apache Commons Net 3.11.1 (`NTPUDPClient`) |
 | DNS | dnsjava 3.6.2 (`SimpleResolver`) |
-| Persistence | AndroidX DataStore (NTP, Ping & Traceroute history) |
+| JS Engine | QuickJS 0.9.2 (`app.cash.quickjs`) — PAC script evaluation |
+| Persistence | AndroidX DataStore (history + global settings) |
 | Testing | JUnit 4, MockK 1.13, Coroutines Test |
 | Min SDK | 26 (Android 8.0) |
 | Target SDK | 35 (Android 15) |
@@ -242,7 +272,7 @@ See [notes/20260501_BulkActions-ADB-Script-fixed.md](notes/20260501_BulkActions-
 ```
 app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/
 ├── MainActivity.kt              # NavHost, bottom navigation bar, NTP screen UI
-├── MoreToolsScreen.kt           # Overflow screen: Traceroute, Port Scanner, LAN Scanner, Google Time Sync, Device Info
+├── MoreToolsScreen.kt           # Overflow screen: Settings, Traceroute, Port Scanner, etc.
 ├── NtpRepository.kt             # NTP network I/O (NTPUDPClient, sealed NtpResult)
 ├── NtpViewModel.kt              # NTP UI state (StateFlow<NtpUiState>), coroutine lifecycle
 ├── NtpHistoryStore.kt           # DataStore persistence for NTP query history
@@ -265,6 +295,20 @@ app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/
 ├── GoogleTimeSyncRepository.kt  # HTTP fetch, XSSI strip, JSON parse, T1/T4 offset calc
 ├── GoogleTimeSyncViewModel.kt   # Idle/Loading/Success/Error StateFlow, syncTime() & reset()
 ├── GoogleTimeSyncScreen.kt      # Google Time Sync screen composable
+├── HttpsCertRepository.kt       # TLS handshake, cert extraction, CONNECT tunnel for proxied SSL
+├── HttpsCertViewModel.kt        # HTTPS Cert Inspector state, history, fetchCert()
+├── HttpsCertScreen.kt           # HTTPS Certificate screen composable
+├── HttpsCertHistoryStore.kt     # DataStore persistence for cert inspection history
+├── SettingsViewModel.kt         # Settings state: timeout, proxy config, PAC URL validation
+├── SettingsScreen.kt            # Settings screen: timeout input, proxy toggle/URL/test
+├── settings/
+│   ├── SettingsDataStore.kt     # DataStore keys: timeout, proxy_enabled, pac_url, etc.
+│   ├── SettingsRepository.kt    # Reactive flows + mutations for all persisted settings
+│   └── ProxyConfig.kt           # Data class for proxy PAC configuration
+├── proxy/
+│   ├── JsEngine.kt              # Interface for PAC script evaluation
+│   ├── QuickJsEngine.kt         # QuickJS-based FindProxyForURL evaluator
+│   └── ProxyResolver.kt         # PAC fetch, eval, parse, cache, proxy test
 ├── deviceinfo/
 │   ├── DeviceInfoModels.kt      # Data models: DeviceInfo, CertificateInfo, DeviceInfoState
 │   ├── SystemInfoRepository.kt  # System API calls: identity, network, battery, storage, MDM, certs
@@ -300,14 +344,14 @@ adb shell am start -n io.github.mobilutils.ntp_dig_ping_more/.MainActivity
 
 ## Testing
 
-This project includes a unit test suite (70+ tests) covering business logic, ViewModels, and data parsing.
+This project includes a unit test suite (255 tests) covering business logic, ViewModels, proxy resolution, and data parsing.
 
 ```bash
 # Run all unit tests
 ./gradlew test
 
 # Run specific test class
-./gradlew test --tests "NtpViewModelTest"
+./gradlew testDebugUnitTest --tests "io.github.mobilutils.ntp_dig_ping_more.ProxyResolverTest"
 ```
 
 See [TESTING.md](TESTING.md) for details.
@@ -337,6 +381,9 @@ See [TESTING.md](TESTING.md) for details.
 | No Network | Device has no active internet connection |
 | HTTP Error | Non-200 response from the Google Time endpoint |
 | Parse Error | Response body missing XSSI prefix or invalid JSON |
+| Untrusted Chain | TLS certificate chain failed PKIX validation |
+| Cert Expired | TLS certificate validity period has lapsed |
+| CONNECT Failed | Proxy rejected the HTTP CONNECT tunnel request |
 | Error | Any other unexpected exception |
 
 ## License

--- a/README.md
+++ b/README.md
@@ -170,6 +170,19 @@ connect.hostinger.com.   120  IN  A      34.120.137.41
 
 **Timeout precedence:** per-command `-t` > config-level `"timeout"` > default 30s.
 
+**Proxy PAC override (`url-proxypac`):** An optional global field that specifies a PAC script URL for proxy routing. When set, the HTTP-based pseudo-commands `checkcert` and `google-timesync` route traffic through the proxy resolved by the PAC script. This is independent of the app's Settings proxy configuration and does not modify persisted settings.
+
+```json
+{
+  "url-proxypac": "http://proxy.corp.com/proxy.pac",
+  "output-file": "~/files/results.txt",
+  "run": {
+    "cert_google": "checkcert -p 443 google.com",
+    "timesync":    "google-timesync"
+  }
+}
+```
+
 ### 🤖 ADB Automation (headless / CI)
 
 Bulk Actions supports fully automated execution via ADB intent extras — **no user interaction required**.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "io.github.mobilutils.ntp_dig_ping_more"
         minSdk = 26
         targetSdk { version = release(rootProject.extra["defaultTargetSdkVersion"] as Int) }
-        versionCode = 19
-        versionName = "2.80"
+        versionCode = 20
+        versionName = "2.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -124,6 +124,9 @@ dependencies {
 
     // dnsjava – full DNS resolution (records, TTL, CNAME chains)
     implementation(libs.dnsjava)
+
+    // QuickJS – lightweight JS engine for PAC script evaluation
+    implementation(libs.quickjs)
 
     testImplementation(libs.junit)
     testImplementation(libs.mockk)

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
@@ -3,6 +3,7 @@ package io.github.mobilutils.ntp_dig_ping_more
 import android.content.Context
 import android.os.Environment
 import io.github.mobilutils.ntp_dig_ping_more.deviceinfo.SystemInfoRepository
+import io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyResolver
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -34,12 +35,16 @@ import java.util.concurrent.atomic.AtomicBoolean
  * @param commands    Ordered command map (key = command name, value = command string).
  * @param timeoutMs   Optional per-command timeout in milliseconds (null = use default 30s).
  * @param outputAsCsv Optional flag to output results as CSV (default false).
+ * @param urlProxyPac Optional PAC script URL. When set, HTTP-based pseudo-commands
+ *                    (checkcert, google-timesync) will route traffic through the
+ *                    proxy resolved by this PAC script.
  */
 data class BulkConfig(
     val outputFile: String?,
     val commands: Map<String, String>,
     val timeoutMs: Long? = null,
     val outputAsCsv: Boolean = false,
+    val urlProxyPac: String? = null,
 )
 
 /**
@@ -153,6 +158,11 @@ object BulkConfigParser {
             root.optBoolean("outputAsCsv", false)
         }.getOrDefault(false)
 
+        val urlProxyPac = runCatching {
+            val url = root.optString("url-proxypac", "")
+            if (url.isNullOrBlank()) null else url.trim()
+        }.getOrNull()
+
         val runObj = root.optJSONObject("run")
             ?: throw IllegalArgumentException("Missing required 'run' object in configuration")
 
@@ -166,7 +176,7 @@ object BulkConfigParser {
             }
         }
 
-        return BulkConfig(outputFile, commands, timeoutMs, outputAsCsv)
+        return BulkConfig(outputFile, commands, timeoutMs, outputAsCsv, urlProxyPac)
     }
 
     /** Expands `~` to the app's private files directory (no permissions needed on SDK 33+). */
@@ -249,6 +259,43 @@ class BulkActionsRepository(
     private val timestampFmt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
 
     /**
+     * Lazily built [ProxyResolver] for the current bulk execution.
+     * Set by [executeCommands] when [BulkConfig.urlProxyPac] is non-null;
+     * reset to null at the start of every execution.
+     */
+    @Volatile
+    private var bulkProxyResolver: ProxyResolver? = null
+
+    /**
+     * Creates a [ProxyResolver] backed by the given PAC URL.
+     *
+     * Uses [ProxyResolver.forStaticPacUrl] to create a resolver that evaluates
+     * the PAC script directly without reading from or writing to the user's
+     * persisted proxy settings.
+     */
+    private fun buildProxyResolver(pacUrl: String): ProxyResolver =
+        ProxyResolver.forStaticPacUrl(pacUrl, context)
+
+    /**
+     * Sets up the proxy resolver for commands that support proxy routing
+     * (`checkcert`, `google-timesync`).
+     *
+     * Call this before [executeSingleCommand] when a `url-proxypac` is defined
+     * in the config. The resolver is used for the lifetime of the bulk execution
+     * and should be cleared via [clearProxyResolver] when execution completes.
+     */
+    fun setupProxyResolver(pacUrl: String?) {
+        bulkProxyResolver = pacUrl?.let { buildProxyResolver(it) }
+    }
+
+    /**
+     * Clears the proxy resolver. Call after bulk execution completes.
+     */
+    fun clearProxyResolver() {
+        bulkProxyResolver = null
+    }
+
+    /**
      * Parses a per-command `-t N` timeout from the command string.
      * Returns the timeout in milliseconds, or null if not present.
      * Example: "ping -c 4 -t 10 google.com" → 10_000L
@@ -270,28 +317,35 @@ class BulkActionsRepository(
         cancellationToken: AtomicBoolean = AtomicBoolean(false),
         onProgress: ((BulkProgress) -> Unit)? = null,
     ): List<BulkCommandResult> {
+        // Set up proxy resolver from config-level PAC URL (if any)
+        bulkProxyResolver = config.urlProxyPac?.let { buildProxyResolver(it) }
+
         val results = mutableListOf<BulkCommandResult>()
         val commands = config.commands.toList()
         val total = commands.size
         val defaultTimeoutMs = config.timeoutMs ?: 30_000L
 
-        commands.forEachIndexed { index, (name, cmd) ->
-            if (cancellationToken.get()) {
-                results.add(BulkCommandTimeout(name, cmd))
-                return@forEachIndexed
+        try {
+            commands.forEachIndexed { index, (name, cmd) ->
+                if (cancellationToken.get()) {
+                    results.add(BulkCommandTimeout(name, cmd))
+                    return@forEachIndexed
+                }
+
+                onProgress?.invoke(BulkProgress(index, total, name, cmd))
+
+                // Per-command `-t N` overrides config-level timeout
+                val commandTimeoutMs = extractCommandTimeout(cmd) ?: defaultTimeoutMs
+
+                val result = withTimeoutOrNull(commandTimeoutMs) {
+                    executeSingleCommand(name, cmd, commandTimeoutMs)
+                }
+
+                val finalResult = result ?: BulkCommandTimeout(name, cmd)
+                results.add(finalResult)
             }
-
-            onProgress?.invoke(BulkProgress(index, total, name, cmd))
-
-            // Per-command `-t N` overrides config-level timeout
-            val commandTimeoutMs = extractCommandTimeout(cmd) ?: defaultTimeoutMs
-
-            val result = withTimeoutOrNull(commandTimeoutMs) {
-                executeSingleCommand(name, cmd, commandTimeoutMs)
-            }
-
-            val finalResult = result ?: BulkCommandTimeout(name, cmd)
-            results.add(finalResult)
+        } finally {
+            bulkProxyResolver = null
         }
 
         return results
@@ -578,7 +632,9 @@ class BulkActionsRepository(
                     parts.getOrNull(portIdx + 2) ?: parts.last()
                 }
 
-                val result = certRepo.fetchCertificate(host, port)
+                // Use proxy-aware repo if bulk config provides a PAC URL
+                val repo = bulkProxyResolver?.let { HttpsCertRepository(proxyResolver = it) } ?: certRepo
+                val result = repo.fetchCertificate(host, port)
                 val duration = System.currentTimeMillis() - t0
 
                 val lines = mutableListOf<String>()
@@ -751,7 +807,8 @@ class BulkActionsRepository(
         return withContext(Dispatchers.IO) {
             try {
                 val t0 = System.currentTimeMillis()
-                val repo = GoogleTimeSyncRepository()
+                // Use proxy-aware repo if bulk config provides a PAC URL
+                val repo = GoogleTimeSyncRepository(proxyResolver = bulkProxyResolver)
                 val result = repo.fetchGoogleTime()
                 val dur = System.currentTimeMillis() - t0
 

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsViewModel.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsViewModel.kt
@@ -248,6 +248,9 @@ class BulkActionsViewModel(
             val defaultTimeoutMs = config.timeoutMs ?: 30_000L
             val allResults = mutableListOf<BulkCommandResult>()
 
+            // Set up proxy resolver from config-level PAC URL (if any)
+            repository.setupProxyResolver(config.urlProxyPac)
+
             try {
                 commands.forEachIndexed { index, (name, cmd) ->
                     if (cancellationToken.get()) {
@@ -293,6 +296,7 @@ class BulkActionsViewModel(
                     autoSavedPath = autoSavedPath,
                 )
             } finally {
+                repository.clearProxyResolver()
                 deleteRunningFile()
             }
         }
@@ -328,6 +332,9 @@ class BulkActionsViewModel(
                 val total = commands.size
                 val defaultTimeoutMs = config.timeoutMs ?: 30_000L
                 val allResults = mutableListOf<BulkCommandResult>()
+
+                // Set up proxy resolver from config-level PAC URL (if any)
+                repository.setupProxyResolver(config.urlProxyPac)
 
                 commands.forEachIndexed { index, (name, cmd) ->
                     if (cancellationToken.get()) {
@@ -375,6 +382,7 @@ class BulkActionsViewModel(
                     autoSavedPath = autoSavedPath,
                 )
             } finally {
+                repository.clearProxyResolver()
                 deleteRunningFile()
             }
         }

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/GoogleTimeSyncRepository.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/GoogleTimeSyncRepository.kt
@@ -1,5 +1,6 @@
 package io.github.mobilutils.ntp_dig_ping_more
 
+import io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyResolver
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
@@ -59,7 +60,9 @@ sealed class GoogleTimeSyncResult {
  * The response is prefixed with `)]}'` (XSSI protection) which is stripped
  * before JSON parsing.
  */
-class GoogleTimeSyncRepository {
+class GoogleTimeSyncRepository(
+    private val proxyResolver: ProxyResolver? = null,
+) {
 
     companion object {
         /** Default endpoint – exposed so the ViewModel and Screen can reference
@@ -87,7 +90,15 @@ class GoogleTimeSyncRepository {
             // T1: record timestamp BEFORE the request goes out.
             val t1 = System.currentTimeMillis()
 
-            connection = (URL(url).openConnection() as HttpURLConnection).apply {
+            // Resolve proxy (if configured); null → direct connection
+            val proxy = proxyResolver?.resolveProxy(url)
+
+            connection = if (proxy != null) {
+                URL(url).openConnection(proxy) as HttpURLConnection
+            } else {
+                URL(url).openConnection() as HttpURLConnection
+            }
+            connection.apply {
                 requestMethod        = "GET"
                 connectTimeout       = CONNECT_TIMEOUT_MS
                 readTimeout          = READ_TIMEOUT_MS

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/GoogleTimeSyncViewModel.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/GoogleTimeSyncViewModel.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyResolver
+import io.github.mobilutils.ntp_dig_ping_more.proxy.QuickJsEngine
 import io.github.mobilutils.ntp_dig_ping_more.settings.SettingsRepository
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
@@ -175,12 +177,16 @@ class GoogleTimeSyncViewModel(
         fun factory(context: Context): ViewModelProvider.Factory =
             object : ViewModelProvider.Factory {
                 @Suppress("UNCHECKED_CAST")
-                override fun <T : ViewModel> create(modelClass: Class<T>): T =
-                    GoogleTimeSyncViewModel(
-                        repository   = GoogleTimeSyncRepository(),
-                        historyStore = GoogleTimeSyncHistoryStore(context.applicationContext),
-                        settingsRepository = SettingsRepository(context.applicationContext),
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val appContext = context.applicationContext
+                    val settingsRepo = SettingsRepository(appContext)
+                    val proxyResolver = ProxyResolver(settingsRepo, QuickJsEngine())
+                    return GoogleTimeSyncViewModel(
+                        repository   = GoogleTimeSyncRepository(proxyResolver),
+                        historyStore = GoogleTimeSyncHistoryStore(appContext),
+                        settingsRepository = settingsRepo,
                     ) as T
+                }
             }
     }
 }

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/HttpsCertRepository.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/HttpsCertRepository.kt
@@ -1,8 +1,12 @@
 package io.github.mobilutils.ntp_dig_ping_more
 
+import io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyResolver
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.BufferedReader
+import java.io.InputStreamReader
 import java.net.InetSocketAddress
+import java.net.Socket
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.security.MessageDigest
@@ -157,7 +161,9 @@ private class RecordingTrustManager(private val systemTm: X509TrustManager) : X5
  * by catching the specific exceptions and mapped to dedicated result types
  * so the UI can still display the parsed certificate fields.
  */
-class HttpsCertRepository {
+class HttpsCertRepository(
+    private val proxyResolver: ProxyResolver? = null,
+) {
 
     companion object {
         private const val CONNECT_TIMEOUT_MS = 10_000
@@ -197,11 +203,24 @@ class HttpsCertRepository {
         var socket: SSLSocket? = null
 
         try {
-            // ── Establish connection ──────────────────────────────────────
-            socket = (sslContext.socketFactory.createSocket() as SSLSocket).also { s ->
-                s.connect(InetSocketAddress(host, port), CONNECT_TIMEOUT_MS)
-                s.soTimeout = READ_TIMEOUT_MS
-                s.useClientMode = true
+            // ── Establish connection (direct or proxied) ─────────────────
+            val proxy = proxyResolver?.resolveProxy("https://$host:$port")
+
+            socket = if (proxy != null && proxy.type() == java.net.Proxy.Type.HTTP) {
+                // HTTP CONNECT tunneling for proxied SSL
+                createProxiedSSLSocket(
+                    targetHost  = host,
+                    targetPort  = port,
+                    proxy       = proxy,
+                    sslFactory  = sslContext.socketFactory,
+                )
+            } else {
+                // Direct connection (no proxy, or SOCKS proxy handled by Socket)
+                (sslContext.socketFactory.createSocket() as SSLSocket).also { s ->
+                    s.connect(InetSocketAddress(host, port), CONNECT_TIMEOUT_MS)
+                    s.soTimeout = READ_TIMEOUT_MS
+                    s.useClientMode = true
+                }
             }
 
             // ── Attempt handshake ─────────────────────────────────────────
@@ -268,6 +287,74 @@ class HttpsCertRepository {
         } finally {
             runCatching { socket?.close() }
         }
+    }
+    // ── CONNECT tunnel (proxied SSL) ───────────────────────────────────────────
+
+    /**
+     * Establishes an HTTP CONNECT tunnel through [proxy], then wraps the raw
+     * socket with SSL for a transparent TLS handshake to [targetHost]:[targetPort].
+     *
+     * Steps:
+     *  1. Open a raw TCP [Socket] to the proxy address.
+     *  2. Send `CONNECT targetHost:targetPort HTTP/1.1\r\n\r\n`.
+     *  3. Read the proxy's response; expect `HTTP/1.x 200 ...`.
+     *  4. Wrap the raw socket with [sslFactory] for the real TLS handshake.
+     *
+     * @throws java.io.IOException if the proxy rejects the CONNECT or if the
+     *         connection cannot be established within [CONNECT_TIMEOUT_MS].
+     */
+    // TODO: Proxy authentication is deferred — CONNECT does not send
+    //       Proxy-Authorization headers. Add support when needed.
+    private fun createProxiedSSLSocket(
+        targetHost: String,
+        targetPort: Int,
+        proxy: java.net.Proxy,
+        sslFactory: javax.net.ssl.SSLSocketFactory,
+    ): SSLSocket {
+        val proxyAddr = proxy.address() as InetSocketAddress
+
+        // 1. Raw TCP connection to the proxy
+        val rawSocket = Socket()
+        rawSocket.connect(
+            InetSocketAddress(proxyAddr.hostString, proxyAddr.port),
+            CONNECT_TIMEOUT_MS,
+        )
+        rawSocket.soTimeout = READ_TIMEOUT_MS
+
+        // 2. Send CONNECT request
+        val connectRequest = "CONNECT $targetHost:$targetPort HTTP/1.1\r\n" +
+                "Host: $targetHost:$targetPort\r\n" +
+                "\r\n"
+        rawSocket.getOutputStream().apply {
+            write(connectRequest.toByteArray(Charsets.US_ASCII))
+            flush()
+        }
+
+        // 3. Read the proxy's response status line and headers
+        val reader = BufferedReader(InputStreamReader(rawSocket.getInputStream(), Charsets.US_ASCII))
+        val statusLine = reader.readLine()
+            ?: throw java.io.IOException("Proxy closed connection before sending CONNECT response")
+
+        // Expect "HTTP/1.x 200 ..."
+        if (!statusLine.contains(" 200 ")) {
+            rawSocket.close()
+            throw java.io.IOException("Proxy CONNECT failed: $statusLine")
+        }
+
+        // Consume remaining headers until the blank line
+        while (true) {
+            val line = reader.readLine() ?: break
+            if (line.isEmpty()) break
+        }
+
+        // 4. Wrap with SSL — autoClose=true so closing SSLSocket also closes rawSocket
+        val sslSocket = sslFactory.createSocket(
+            rawSocket, targetHost, targetPort, /* autoClose = */ true,
+        ) as SSLSocket
+        sslSocket.soTimeout = READ_TIMEOUT_MS
+        sslSocket.useClientMode = true
+
+        return sslSocket
     }
 
     // ── Certificate parsing ───────────────────────────────────────────────────

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/HttpsCertViewModel.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/HttpsCertViewModel.kt
@@ -213,11 +213,18 @@ class HttpsCertViewModel(
         fun factory(context: Context): ViewModelProvider.Factory =
             object : ViewModelProvider.Factory {
                 @Suppress("UNCHECKED_CAST")
-                override fun <T : ViewModel> create(modelClass: Class<T>): T =
-                    HttpsCertViewModel(
-                        repository   = HttpsCertRepository(),
-                        historyStore = HttpsCertHistoryStore(context.applicationContext),
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val appContext = context.applicationContext
+                    val settingsRepo = io.github.mobilutils.ntp_dig_ping_more.settings.SettingsRepository(appContext)
+                    val proxyResolver = io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyResolver(
+                        settingsRepo,
+                        io.github.mobilutils.ntp_dig_ping_more.proxy.QuickJsEngine(),
+                    )
+                    return HttpsCertViewModel(
+                        repository   = HttpsCertRepository(proxyResolver),
+                        historyStore = HttpsCertHistoryStore(appContext),
                     ) as T
+                }
             }
     }
 }

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/SettingsScreen.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/SettingsScreen.kt
@@ -2,31 +2,43 @@ package io.github.mobilutils.ntp_dig_ping_more
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.github.mobilutils.ntp_dig_ping_more.settings.SettingsKeys
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Settings screen
@@ -35,11 +47,14 @@ import io.github.mobilutils.ntp_dig_ping_more.settings.SettingsKeys
 /**
  * Global settings screen.
  *
- * Displays a numeric text field to configure the operation timeout that is
- * applied to all network-based tools (NTP, DIG, Ping, Traceroute, Port Scanner,
- * LAN Scanner, Google Time Sync). Changes are saved immediately on valid input.
- * If the field loses focus while invalid the value is reverted to the last
- * known-good setting.
+ * Displays:
+ *  1. A numeric text field to configure the operation timeout applied to all
+ *     network-based tools.
+ *  2. A Proxy/PAC configuration section with toggle, PAC URL input, and a
+ *     "Test Proxy/PAC" button.
+ *
+ * Changes are saved immediately on valid input. If the timeout field loses
+ * focus while invalid, the value is reverted to the last known-good setting.
  *
  * The top app bar (title = "Settings") is rendered by [AppRoot]'s shared
  * [Scaffold] — this composable only fills the inner content area.
@@ -93,6 +108,110 @@ fun SettingsScreen() {
                 },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             )
+        }
+
+        // ── Proxy Configuration section ───────────────────────────────────────
+        SettingsSectionCard(title = "Proxy Configuration") {
+
+            // Enable/disable toggle
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Enable Proxy",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium,
+                    )
+                    Text(
+                        text = "Route traffic through a PAC-resolved proxy",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = uiState.proxyEnabled,
+                    onCheckedChange = viewModel::onProxyEnabledChange,
+                )
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            // PAC URL input
+            OutlinedTextField(
+                value = uiState.proxyPacUrl,
+                onValueChange = viewModel::onProxyPacUrlChange,
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("PAC URL") },
+                placeholder = { Text("http://proxy.corp.com/proxy.pac") },
+                singleLine = true,
+                enabled = uiState.proxyEnabled,
+                isError = uiState.proxyPacUrlError != null,
+                supportingText = {
+                    when {
+                        uiState.proxyPacUrlError != null -> Text(
+                            text = uiState.proxyPacUrlError!!,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                        uiState.proxyEnabled -> Text(
+                            text = "URL to an auto-configuration (.pac) script",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            // Test Proxy/PAC button
+            Button(
+                onClick = viewModel::testProxy,
+                enabled = uiState.proxyEnabled &&
+                        uiState.proxyPacUrl.isNotBlank() &&
+                        uiState.proxyPacUrlError == null &&
+                        !uiState.isTestingProxy,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.secondary,
+                ),
+            ) {
+                if (uiState.isTestingProxy) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onSecondary,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text("Testing…")
+                } else {
+                    Text("Test Proxy/PAC", fontWeight = FontWeight.Medium)
+                }
+            }
+
+            // Last test result
+            if (uiState.proxyTestResult != null) {
+                Spacer(Modifier.height(12.dp))
+
+                val isSuccess = uiState.proxyTestResult!!.startsWith("✓")
+                Text(
+                    text = uiState.proxyTestResult!!,
+                    style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+                    color = if (isSuccess) MaterialTheme.colorScheme.secondary
+                            else MaterialTheme.colorScheme.error,
+                )
+
+                if (uiState.proxyLastTested > 0) {
+                    val formatted = SimpleDateFormat("yyyy/MM/dd HH:mm:ss", Locale.getDefault())
+                        .format(Date(uiState.proxyLastTested))
+                    Text(
+                        text = "Last tested: $formatted",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/SettingsViewModel.kt
@@ -4,11 +4,17 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyResolver
+import io.github.mobilutils.ntp_dig_ping_more.proxy.QuickJsEngine
+import io.github.mobilutils.ntp_dig_ping_more.settings.ProxyConfig
 import io.github.mobilutils.ntp_dig_ping_more.settings.SettingsKeys
 import io.github.mobilutils.ntp_dig_ping_more.settings.SettingsRepository
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -18,15 +24,28 @@ import kotlinx.coroutines.launch
 /**
  * Complete UI state for the Settings screen.
  *
- * @param timeoutInput  Raw text currently shown in the timeout text field.
- * @param isError       True when [timeoutInput] is out of the allowed range or non-numeric.
- * @param savedTimeout  The last successfully saved value; used to restore the
- *                      field if the user leaves it in an invalid state.
+ * @param timeoutInput     Raw text currently shown in the timeout text field.
+ * @param isError          True when [timeoutInput] is out of the allowed range or non-numeric.
+ * @param savedTimeout     The last successfully saved value; used to restore the
+ *                         field if the user leaves it in an invalid state.
+ * @param proxyEnabled     Whether proxy routing is currently active.
+ * @param proxyPacUrl      Text in the PAC URL field.
+ * @param proxyPacUrlError Inline validation error for the PAC URL, or null if valid.
+ * @param isTestingProxy   True while a proxy connectivity test is in progress.
+ * @param proxyTestResult  Human-readable result of the last test, or null if never tested.
+ * @param proxyLastTested  Epoch millis of the last test, or 0 if never tested.
  */
 data class SettingsUiState(
     val timeoutInput: String = SettingsKeys.DEFAULT_TIMEOUT_SECONDS.toString(),
     val isError: Boolean = false,
     val savedTimeout: Int = SettingsKeys.DEFAULT_TIMEOUT_SECONDS,
+    // Proxy / PAC fields
+    val proxyEnabled: Boolean = false,
+    val proxyPacUrl: String = "",
+    val proxyPacUrlError: String? = null,
+    val isTestingProxy: Boolean = false,
+    val proxyTestResult: String? = null,
+    val proxyLastTested: Long = 0L,
 )
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -42,13 +61,21 @@ data class SettingsUiState(
  *  - Save valid values immediately via [SettingsRepository.updateTimeout].
  *  - Revert the text field to the last known-good value on explicit [revert] call
  *    (e.g. when focus leaves an invalid field).
+ *  - Manage the Proxy/PAC configuration (enable/disable, PAC URL, test connectivity).
  */
 class SettingsViewModel(
     private val settingsRepository: SettingsRepository,
+    private val proxyResolver: ProxyResolver,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+    /** Debounce job for PAC URL validation. */
+    private var pacUrlDebounceJob: Job? = null
+
+    /** Job for the current proxy test, so it can be cancelled if needed. */
+    private var testJob: Job? = null
 
     init {
         // Seed the text field from the persisted value (handles first-launch default too).
@@ -67,9 +94,20 @@ class SettingsViewModel(
                 }
             }
         }
+
+        // Load persisted proxy config on creation
+        viewModelScope.launch {
+            val config = settingsRepository.proxyConfigFlow.first()
+            _uiState.value = _uiState.value.copy(
+                proxyEnabled    = config.enabled,
+                proxyPacUrl     = config.pacUrl,
+                proxyLastTested = config.lastTested,
+                proxyTestResult = config.lastTestResult,
+            )
+        }
     }
 
-    // ── User actions ──────────────────────────────────────────────────────────
+    // ── Timeout actions ──────────────────────────────────────────────────────
 
     /**
      * Called on every keystroke in the timeout text field.
@@ -112,6 +150,114 @@ class SettingsViewModel(
         )
     }
 
+    // ── Proxy / PAC actions ──────────────────────────────────────────────────
+
+    /**
+     * Toggles proxy routing on/off and persists immediately.
+     */
+    fun onProxyEnabledChange(enabled: Boolean) {
+        _uiState.value = _uiState.value.copy(proxyEnabled = enabled)
+        viewModelScope.launch {
+            saveCurrentProxyConfig()
+        }
+    }
+
+    /**
+     * Called on every keystroke in the PAC URL text field.
+     *
+     * Validation is debounced by 300 ms to avoid distracting the user
+     * while they are still typing. Valid URLs are persisted; invalid
+     * ones set [SettingsUiState.proxyPacUrlError].
+     */
+    fun onProxyPacUrlChange(url: String) {
+        _uiState.value = _uiState.value.copy(
+            proxyPacUrl = url,
+            proxyPacUrlError = null, // clear error immediately while typing
+        )
+
+        // Clear proxy cache when URL changes
+        proxyResolver.clearCache()
+
+        pacUrlDebounceJob?.cancel()
+        pacUrlDebounceJob = viewModelScope.launch {
+            delay(300) // debounce
+
+            val error = validatePacUrl(url)
+            _uiState.value = _uiState.value.copy(proxyPacUrlError = error)
+
+            if (error == null) {
+                saveCurrentProxyConfig()
+            }
+        }
+    }
+
+    /**
+     * Tests proxy connectivity and updates the UI with the result.
+     */
+    fun testProxy() {
+        testJob?.cancel()
+        _uiState.value = _uiState.value.copy(isTestingProxy = true)
+
+        testJob = viewModelScope.launch {
+            val result = proxyResolver.testProxy()
+            val now = System.currentTimeMillis()
+
+            _uiState.value = _uiState.value.copy(
+                isTestingProxy  = false,
+                proxyTestResult = result.message,
+                proxyLastTested = now,
+            )
+
+            // Persist test result
+            saveCurrentProxyConfig(
+                overrideLastTested = now,
+                overrideTestResult = result.message,
+            )
+        }
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    /**
+     * Validates a PAC URL string.
+     *
+     * @return An error message, or `null` if the URL is valid (or empty, since
+     *         an empty URL simply means "no proxy configured").
+     */
+    internal fun validatePacUrl(url: String): String? {
+        if (url.isBlank()) return null // empty is allowed — means disabled
+        return try {
+            val parsed = java.net.URL(url)
+            when {
+                parsed.protocol !in listOf("http", "https") ->
+                    "Only http:// and https:// URLs are supported"
+                parsed.host.isNullOrBlank() ->
+                    "URL must contain a hostname"
+                else -> null
+            }
+        } catch (_: Exception) {
+            "Invalid URL format"
+        }
+    }
+
+    /**
+     * Persists the current proxy config from UI state to DataStore.
+     */
+    private suspend fun saveCurrentProxyConfig(
+        overrideLastTested: Long? = null,
+        overrideTestResult: String? = null,
+    ) {
+        val state = _uiState.value
+        settingsRepository.saveProxyConfig(
+            ProxyConfig(
+                enabled        = state.proxyEnabled,
+                pacUrl         = state.proxyPacUrl,
+                lastTested     = overrideLastTested ?: state.proxyLastTested,
+                lastTestResult = overrideTestResult ?: state.proxyTestResult,
+            )
+        )
+    }
+
     // ── Factory ───────────────────────────────────────────────────────────────
 
     companion object {
@@ -119,10 +265,15 @@ class SettingsViewModel(
         fun factory(context: Context): ViewModelProvider.Factory =
             object : ViewModelProvider.Factory {
                 @Suppress("UNCHECKED_CAST")
-                override fun <T : ViewModel> create(modelClass: Class<T>): T =
-                    SettingsViewModel(
-                        settingsRepository = SettingsRepository(context.applicationContext),
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val appContext = context.applicationContext
+                    val settingsRepo = SettingsRepository(appContext)
+                    val proxyResolver = ProxyResolver(settingsRepo, QuickJsEngine())
+                    return SettingsViewModel(
+                        settingsRepository = settingsRepo,
+                        proxyResolver      = proxyResolver,
                     ) as T
+                }
             }
     }
 }

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/JsEngine.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/JsEngine.kt
@@ -1,0 +1,23 @@
+package io.github.mobilutils.ntp_dig_ping_more.proxy
+
+/**
+ * Abstraction over a JavaScript engine used to evaluate PAC scripts.
+ *
+ * Implementations must be safe to call from [kotlinx.coroutines.Dispatchers.IO].
+ * The engine should evaluate the standard `FindProxyForURL(url, host)` function
+ * defined in the PAC script and return the raw result string.
+ */
+interface JsEngine {
+
+    /**
+     * Evaluates a PAC script's `FindProxyForURL` function.
+     *
+     * @param pacScript   The full PAC JavaScript source code.
+     * @param targetUrl   The URL being requested (e.g. `http://example.com/path`).
+     * @param targetHost  The hostname portion of [targetUrl] (e.g. `example.com`).
+     * @return The raw PAC result string, e.g. `"PROXY 10.0.0.1:8080"`,
+     *         `"DIRECT"`, or a semicolon-separated fallback chain.
+     * @throws Exception if the script is malformed or evaluation fails.
+     */
+    fun evaluatePac(pacScript: String, targetUrl: String, targetHost: String): String
+}

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/ProxyResolver.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/ProxyResolver.kt
@@ -44,10 +44,15 @@ data class ProxyTestResult(
  *
  * @param settingsRepository  Source of the persisted [ProxyConfig].
  * @param jsEngine            JS engine used to evaluate `FindProxyForURL`.
+ * @param staticPacUrl        Optional PAC URL override. When non-null, the resolver
+ *                            uses this URL directly instead of reading from
+ *                            [settingsRepository]. Used by BulkActions for
+ *                            config-level `url-proxypac` without touching persisted settings.
  */
 class ProxyResolver(
     private val settingsRepository: SettingsRepository,
     private val jsEngine: JsEngine,
+    private val staticPacUrl: String? = null,
 ) {
 
     companion object {
@@ -59,6 +64,27 @@ class ProxyResolver(
 
         private const val CONNECT_TIMEOUT_MS = 10_000
         private const val READ_TIMEOUT_MS    = 10_000
+
+        /**
+         * Creates a [ProxyResolver] that uses a static PAC URL directly,
+         * without reading from or writing to [SettingsRepository].
+         *
+         * Intended for BulkActions where the PAC URL comes from the JSON config
+         * and should not affect the user's persisted proxy settings.
+         *
+         * @param pacUrl    PAC script URL (e.g. `http://proxy.corp.com/proxy.pac`).
+         * @param context   Application context (needed by [SettingsRepository] internally).
+         * @param jsEngine  JS engine for PAC evaluation (default: [QuickJsEngine]).
+         */
+        fun forStaticPacUrl(
+            pacUrl: String,
+            context: android.content.Context,
+            jsEngine: JsEngine = QuickJsEngine(),
+        ): ProxyResolver = ProxyResolver(
+            settingsRepository = SettingsRepository(context),
+            jsEngine = jsEngine,
+            staticPacUrl = pacUrl,
+        )
     }
 
     // ── PAC script cache ─────────────────────────────────────────────────────
@@ -83,8 +109,14 @@ class ProxyResolver(
      */
     suspend fun resolveProxy(targetUrl: String): Proxy? = withContext(Dispatchers.IO) {
         try {
-            val config = settingsRepository.proxyConfigFlow.first()
-            if (!config.enabled || config.pacUrl.isBlank()) return@withContext null
+            // Determine the effective PAC URL: static override or persisted config
+            val effectivePacUrl = if (staticPacUrl != null) {
+                staticPacUrl
+            } else {
+                val config = settingsRepository.proxyConfigFlow.first()
+                if (!config.enabled || config.pacUrl.isBlank()) return@withContext null
+                config.pacUrl
+            }
 
             val host = extractHost(targetUrl) ?: return@withContext null
 
@@ -99,7 +131,7 @@ class ProxyResolver(
             }
 
             // Fetch (or use cached) PAC script
-            val pacScript = fetchPacScript(config.pacUrl) ?: return@withContext null
+            val pacScript = fetchPacScript(effectivePacUrl) ?: return@withContext null
 
             // Evaluate FindProxyForURL
             val pacResult = try {

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/ProxyResolver.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/ProxyResolver.kt
@@ -1,0 +1,288 @@
+package io.github.mobilutils.ntp_dig_ping_more.proxy
+
+import io.github.mobilutils.ntp_dig_ping_more.settings.ProxyConfig
+import io.github.mobilutils.ntp_dig_ping_more.settings.SettingsRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import java.net.HttpURLConnection
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.URL
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test result
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Result of a proxy connectivity test.
+ *
+ * @param success  True if the test request completed with HTTP 204 (or 200).
+ * @param message  Human-readable description of the outcome.
+ * @param latencyMs Round-trip time in milliseconds (0 on failure).
+ */
+data class ProxyTestResult(
+    val success: Boolean,
+    val message: String,
+    val latencyMs: Long = 0L,
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Proxy resolver
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolves a [java.net.Proxy] for a given target URL by fetching and
+ * evaluating a PAC script from the user's configured PAC URL.
+ *
+ * **Caching:**
+ *  - The PAC script body is cached for [PAC_CACHE_TTL_MS] (5 minutes).
+ *  - Resolved proxy results are cached per host for the same TTL.
+ *
+ * **Failure handling:** Any failure (network, JS eval, parse) silently
+ * returns `null`, meaning the caller should use a DIRECT connection.
+ *
+ * @param settingsRepository  Source of the persisted [ProxyConfig].
+ * @param jsEngine            JS engine used to evaluate `FindProxyForURL`.
+ */
+class ProxyResolver(
+    private val settingsRepository: SettingsRepository,
+    private val jsEngine: JsEngine,
+) {
+
+    companion object {
+        /** Cache TTL for both the PAC script body and per-host resolutions. */
+        private const val PAC_CACHE_TTL_MS = 5 * 60 * 1000L   // 5 minutes
+
+        /** Connectivity-check URL used by [testProxy]. */
+        private const val TEST_URL = "http://connectivitycheck.gstatic.com/generate_204"
+
+        private const val CONNECT_TIMEOUT_MS = 10_000
+        private const val READ_TIMEOUT_MS    = 10_000
+    }
+
+    // ── PAC script cache ─────────────────────────────────────────────────────
+
+    @Volatile private var cachedPacScript: String? = null
+    @Volatile private var cachedPacUrl: String? = null
+    @Volatile private var pacFetchedAt: Long = 0L
+
+    // ── Per-host proxy cache ─────────────────────────────────────────────────
+
+    private data class CachedProxy(val proxy: Proxy?, val resolvedAt: Long)
+
+    private val proxyCache = mutableMapOf<String, CachedProxy>()
+
+    // ── Public API ───────────────────────────────────────────────────────────
+
+    /**
+     * Resolves the proxy to use for [targetUrl].
+     *
+     * @return A [Proxy] instance, or `null` if the connection should be DIRECT
+     *         (proxy disabled, resolution failure, or PAC says DIRECT).
+     */
+    suspend fun resolveProxy(targetUrl: String): Proxy? = withContext(Dispatchers.IO) {
+        try {
+            val config = settingsRepository.proxyConfigFlow.first()
+            if (!config.enabled || config.pacUrl.isBlank()) return@withContext null
+
+            val host = extractHost(targetUrl) ?: return@withContext null
+
+            // Check per-host cache
+            val now = System.currentTimeMillis()
+            synchronized(proxyCache) {
+                proxyCache[host]?.let { cached ->
+                    if (now - cached.resolvedAt < PAC_CACHE_TTL_MS) {
+                        return@withContext cached.proxy
+                    }
+                }
+            }
+
+            // Fetch (or use cached) PAC script
+            val pacScript = fetchPacScript(config.pacUrl) ?: return@withContext null
+
+            // Evaluate FindProxyForURL
+            val pacResult = try {
+                jsEngine.evaluatePac(pacScript, targetUrl, host)
+            } catch (_: Exception) {
+                return@withContext null
+            }
+
+            // Parse PAC result into a Proxy
+            val proxy = parsePacResult(pacResult)
+
+            // Cache the result
+            synchronized(proxyCache) {
+                proxyCache[host] = CachedProxy(proxy, now)
+            }
+
+            proxy
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Performs a lightweight connectivity test through the resolved proxy.
+     *
+     * Sends a HEAD request to Google's connectivity-check endpoint
+     * ([TEST_URL]) and reports success/failure with latency.
+     */
+    suspend fun testProxy(): ProxyTestResult = withContext(Dispatchers.IO) {
+        var connection: HttpURLConnection? = null
+        try {
+            val proxy = resolveProxy(TEST_URL)
+            val startMs = System.currentTimeMillis()
+
+            connection = if (proxy != null) {
+                URL(TEST_URL).openConnection(proxy) as HttpURLConnection
+            } else {
+                URL(TEST_URL).openConnection() as HttpURLConnection
+            }
+
+            connection.apply {
+                requestMethod = "HEAD"
+                connectTimeout = CONNECT_TIMEOUT_MS
+                readTimeout = READ_TIMEOUT_MS
+                instanceFollowRedirects = true
+            }
+
+            val code = connection.responseCode
+            val latencyMs = System.currentTimeMillis() - startMs
+
+            if (code in 200..299) {
+                val via = if (proxy != null) "via ${proxy.address()}" else "DIRECT"
+                ProxyTestResult(
+                    success   = true,
+                    message   = "✓ HTTP $code $via (${latencyMs}ms)",
+                    latencyMs = latencyMs,
+                )
+            } else {
+                ProxyTestResult(
+                    success = false,
+                    message = "✗ HTTP $code (${latencyMs}ms)",
+                    latencyMs = latencyMs,
+                )
+            }
+        } catch (e: Exception) {
+            ProxyTestResult(
+                success = false,
+                message = "✗ ${e.localizedMessage ?: "Connection failed"}",
+            )
+        } finally {
+            connection?.disconnect()
+        }
+    }
+
+    /**
+     * Clears all cached PAC scripts and per-host proxy resolutions.
+     * Call this when the user changes the PAC URL.
+     */
+    fun clearCache() {
+        cachedPacScript = null
+        cachedPacUrl = null
+        pacFetchedAt = 0L
+        synchronized(proxyCache) { proxyCache.clear() }
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    /**
+     * Fetches the PAC script from [pacUrl], using a 5-minute in-memory cache.
+     */
+    private fun fetchPacScript(pacUrl: String): String? {
+        val now = System.currentTimeMillis()
+        if (cachedPacScript != null &&
+            cachedPacUrl == pacUrl &&
+            now - pacFetchedAt < PAC_CACHE_TTL_MS
+        ) {
+            return cachedPacScript
+        }
+
+        var connection: HttpURLConnection? = null
+        return try {
+            connection = (URL(pacUrl).openConnection() as HttpURLConnection).apply {
+                requestMethod = "GET"
+                connectTimeout = CONNECT_TIMEOUT_MS
+                readTimeout = READ_TIMEOUT_MS
+                instanceFollowRedirects = true
+            }
+
+            if (connection.responseCode != HttpURLConnection.HTTP_OK) {
+                return null
+            }
+
+            val script = connection.inputStream.bufferedReader(Charsets.UTF_8).readText()
+            cachedPacScript = script
+            cachedPacUrl = pacUrl
+            pacFetchedAt = now
+            script
+        } catch (_: Exception) {
+            null
+        } finally {
+            connection?.disconnect()
+        }
+    }
+
+    /**
+     * Extracts the hostname from a URL string.
+     */
+    private fun extractHost(url: String): String? = try {
+        URL(url).host.takeIf { it.isNotBlank() }
+    } catch (_: Exception) {
+        // Try simple extraction for non-URL strings (e.g. bare hostnames)
+        url.removePrefix("https://").removePrefix("http://")
+            .substringBefore("/").substringBefore(":").takeIf { it.isNotBlank() }
+    }
+
+    // ── PAC result parsing ───────────────────────────────────────────────────
+
+    /**
+     * Parses a PAC result string into a [Proxy].
+     *
+     * Supports:
+     *  - `"DIRECT"` → returns `null`
+     *  - `"PROXY host:port"` → returns [Proxy.Type.HTTP]
+     *  - `"SOCKS host:port"` → returns [Proxy.Type.SOCKS]
+     *  - Fallback chains separated by `;` — uses the first valid entry
+     *
+     * @return A [Proxy] or `null` (meaning DIRECT).
+     */
+    internal fun parsePacResult(pacResult: String): Proxy? {
+        val entries = pacResult.split(";").map { it.trim() }.filter { it.isNotEmpty() }
+        for (entry in entries) {
+            val upper = entry.uppercase()
+            when {
+                upper == "DIRECT" -> return null
+
+                upper.startsWith("PROXY ") -> {
+                    val address = entry.substring(6).trim()
+                    val proxy = parseAddress(address, Proxy.Type.HTTP)
+                    if (proxy != null) return proxy
+                    // Malformed — try next entry in fallback chain
+                }
+
+                upper.startsWith("SOCKS ") || upper.startsWith("SOCKS5 ") || upper.startsWith("SOCKS4 ") -> {
+                    val spaceIdx = entry.indexOf(' ')
+                    val address = entry.substring(spaceIdx + 1).trim()
+                    val proxy = parseAddress(address, Proxy.Type.SOCKS)
+                    if (proxy != null) return proxy
+                }
+            }
+        }
+        // No valid entry found — fall back to DIRECT
+        return null
+    }
+
+    /**
+     * Parses `"host:port"` into an [InetSocketAddress]-backed [Proxy].
+     */
+    private fun parseAddress(address: String, type: Proxy.Type): Proxy? {
+        val parts = address.split(":")
+        if (parts.size != 2) return null
+        val host = parts[0].trim()
+        val port = parts[1].trim().toIntOrNull() ?: return null
+        if (host.isEmpty() || port !in 1..65535) return null
+        return Proxy(type, InetSocketAddress.createUnresolved(host, port))
+    }
+}

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/QuickJsEngine.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/QuickJsEngine.kt
@@ -1,0 +1,87 @@
+package io.github.mobilutils.ntp_dig_ping_more.proxy
+
+import app.cash.quickjs.QuickJs
+
+/**
+ * [JsEngine] implementation backed by [QuickJs] (app.cash.quickjs).
+ *
+ * Each [evaluatePac] call creates a fresh QuickJS runtime, loads the PAC
+ * script, invokes `FindProxyForURL(url, host)`, and tears down the runtime.
+ * This is safe for concurrent use because no shared mutable state exists
+ * between invocations.
+ *
+ * **Threading:** Callers must invoke this on [kotlinx.coroutines.Dispatchers.IO].
+ *
+ * A minimal set of PAC helper functions (`isPlainHostName`, `dnsDomainIs`,
+ * `shExpMatch`, `isInNet`, `myIpAddress`, `dnsResolve`, `dnsDomainLevels`,
+ * `localHostOrDomainIs`) is prepended so that common PAC scripts work
+ * out of the box without requiring a full browser environment.
+ */
+class QuickJsEngine : JsEngine {
+
+    companion object {
+        /**
+         * Minimal PAC utility stubs required by the PAC specification.
+         *
+         * Real DNS resolution (`dnsResolve`, `isInNet`) is stubbed to return
+         * safe defaults. A production-grade implementation would perform
+         * actual DNS lookups, but that requires Android-specific APIs and
+         * significantly complicates the JS engine lifecycle.
+         */
+        // TODO: Consider implementing real DNS resolution for isInNet/dnsResolve
+        //       if corporate PAC scripts require accurate subnet matching.
+        private val PAC_UTILS = """
+            function isPlainHostName(host) {
+                return host.indexOf('.') === -1;
+            }
+            function dnsDomainIs(host, domain) {
+                var d = domain;
+                if (d.charAt(0) !== '.') d = '.' + d;
+                return host.length >= d.length &&
+                       host.substring(host.length - d.length) === d;
+            }
+            function localHostOrDomainIs(host, hostdom) {
+                return host === hostdom ||
+                       hostdom.indexOf(host + '.') === 0;
+            }
+            function isResolvable(host) { return true; }
+            function isInNet(host, pattern, mask) { return false; }
+            function dnsResolve(host) { return '127.0.0.1'; }
+            function myIpAddress() { return '127.0.0.1'; }
+            function dnsDomainLevels(host) {
+                var s = host.split('.');
+                return s.length - 1;
+            }
+            function shExpMatch(str, shexp) {
+                var re = shexp.replace(/\./g, '\\\\.').replace(/\*/g, '.*').replace(/\?/g, '.');
+                return new RegExp('^' + re + '$').test(str);
+            }
+            function weekdayRange() { return true; }
+            function dateRange() { return true; }
+            function timeRange() { return true; }
+        """.trimIndent()
+    }
+
+    override fun evaluatePac(pacScript: String, targetUrl: String, targetHost: String): String {
+        val engine = QuickJs.create()
+        try {
+            // Load PAC utilities + the actual PAC script
+            engine.evaluate(PAC_UTILS)
+            engine.evaluate(pacScript)
+
+            // Invoke FindProxyForURL and return the result
+            val result = engine.evaluate(
+                "FindProxyForURL('${escapeJs(targetUrl)}', '${escapeJs(targetHost)}');"
+            )
+            return result?.toString() ?: "DIRECT"
+        } finally {
+            engine.close()
+        }
+    }
+
+    /**
+     * Escapes single quotes and backslashes for safe embedding in a JS string literal.
+     */
+    private fun escapeJs(value: String): String =
+        value.replace("\\", "\\\\").replace("'", "\\'")
+}

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/settings/ProxyConfig.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/settings/ProxyConfig.kt
@@ -1,0 +1,16 @@
+package io.github.mobilutils.ntp_dig_ping_more.settings
+
+/**
+ * Holds the user's Proxy/PAC configuration, persisted in DataStore.
+ *
+ * @param enabled         Whether proxy routing is active.
+ * @param pacUrl          URL to a PAC script (e.g. `http://proxy.corp.com/proxy.pac`).
+ * @param lastTested      Epoch millis of the last "Test Proxy" action, or 0 if never tested.
+ * @param lastTestResult  Human-readable result of the last test (null if never tested).
+ */
+data class ProxyConfig(
+    val enabled: Boolean = false,
+    val pacUrl: String = "",
+    val lastTested: Long = 0L,
+    val lastTestResult: String? = null,
+)

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/settings/SettingsDataStore.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/settings/SettingsDataStore.kt
@@ -3,7 +3,10 @@ package io.github.mobilutils.ntp_dig_ping_more.settings
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -39,4 +42,18 @@ object SettingsKeys {
 
     /** Maximum accepted timeout value. */
     const val MAX_TIMEOUT_SECONDS: Int = 60
+
+    // ── Proxy / PAC keys ─────────────────────────────────────────────────────
+
+    /** Whether proxy routing is enabled. */
+    val PROXY_ENABLED = booleanPreferencesKey("proxy_enabled")
+
+    /** URL to a PAC auto-configuration script. */
+    val PROXY_PAC_URL = stringPreferencesKey("proxy_pac_url")
+
+    /** Epoch millis of the last "Test Proxy" action. */
+    val PROXY_LAST_TESTED = longPreferencesKey("proxy_last_tested")
+
+    /** Human-readable result string of the last proxy test. */
+    val PROXY_LAST_TEST_RESULT = stringPreferencesKey("proxy_last_test_result")
 }

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/settings/SettingsRepository.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/settings/SettingsRepository.kt
@@ -51,4 +51,36 @@ class SettingsRepository(private val context: Context) {
             prefs[SettingsKeys.TIMEOUT_SECONDS] = clamped
         }
     }
+
+    // ── Proxy / PAC ──────────────────────────────────────────────────────────
+
+    /**
+     * Emits the current [ProxyConfig] whenever any proxy-related key changes.
+     *
+     * Defaults to a disabled config with empty PAC URL on first launch.
+     */
+    val proxyConfigFlow: Flow<ProxyConfig> = context.settingsDataStore.data.map { prefs ->
+        ProxyConfig(
+            enabled        = prefs[SettingsKeys.PROXY_ENABLED] ?: false,
+            pacUrl         = prefs[SettingsKeys.PROXY_PAC_URL] ?: "",
+            lastTested     = prefs[SettingsKeys.PROXY_LAST_TESTED] ?: 0L,
+            lastTestResult = prefs[SettingsKeys.PROXY_LAST_TEST_RESULT],
+        )
+    }
+
+    /**
+     * Persists the full [ProxyConfig] atomically.
+     */
+    suspend fun saveProxyConfig(config: ProxyConfig) {
+        context.settingsDataStore.edit { prefs ->
+            prefs[SettingsKeys.PROXY_ENABLED]          = config.enabled
+            prefs[SettingsKeys.PROXY_PAC_URL]           = config.pacUrl
+            prefs[SettingsKeys.PROXY_LAST_TESTED]       = config.lastTested
+            if (config.lastTestResult != null) {
+                prefs[SettingsKeys.PROXY_LAST_TEST_RESULT] = config.lastTestResult
+            } else {
+                prefs.remove(SettingsKeys.PROXY_LAST_TEST_RESULT)
+            }
+        }
+    }
 }

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkConfigParserTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkConfigParserTest.kt
@@ -30,6 +30,9 @@ class BulkConfigParserTest {
         // Extract "timeout" value (mirrors production parsing)
         val timeoutMs = extractLongField(trimmed, "timeout")?.takeIf { it > 0 }?.let { it * 1000L }
 
+        // Extract "url-proxypac" value
+        val urlProxyPac = extractStringField(trimmed, "url-proxypac")
+
         // Extract "run" object
         val runMatch = Regex("""\"run\"\s*:\s*\{([^}]*)\}""").find(trimmed)
             ?: throw IllegalArgumentException("Missing required 'run' object in configuration")
@@ -37,7 +40,7 @@ class BulkConfigParserTest {
         val runContent = runMatch.groupValues[1]
         val commands = mutableMapOf<String, String>()
 
-        val commandPattern = Regex("""\"([^\"]+)\"\s*:\s*\"([^\"]*)\"""")
+        val commandPattern = Regex("""\"([^\"]+)\"\s*:\s*\"([^\"]*)\"""") 
         commandPattern.findAll(runContent).forEach { match ->
             val key = match.groupValues[1]
             val value = match.groupValues[2].trim()
@@ -46,7 +49,7 @@ class BulkConfigParserTest {
             }
         }
 
-        return BulkConfig(outputFile, commands, timeoutMs)
+        return BulkConfig(outputFile, commands, timeoutMs, urlProxyPac = urlProxyPac)
     }
 
     /** Extracts a long field value from JSON, returning null if not found. */
@@ -345,4 +348,79 @@ class BulkConfigParserTest {
         assertEquals(2004L, result.durationMs)
         assertTrue(result.outputLines.any { "No open ports found" in it })
      }
+
+    // ────────────────────────────────────────────────────────────────
+    // url-proxypac tests
+    // ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `parseConfigWithUrlProxyPac returns value`() {
+        val json = """
+            {
+                "url-proxypac": "http://proxy.corp.com/proxy.pac",
+                "run": {
+                    "cmd1": "checkcert -p 443 google.com"
+                }
+            }
+        """.trimIndent()
+
+        val config = parseBulkConfig(json)
+
+        assertEquals("http://proxy.corp.com/proxy.pac", config.urlProxyPac)
+    }
+
+    @Test
+    fun `parseConfigWithoutUrlProxyPac returns null`() {
+        val json = """
+            {
+                "run": {
+                    "cmd1": "ping -c 1 example.com"
+                }
+            }
+        """.trimIndent()
+
+        val config = parseBulkConfig(json)
+
+        assertNull(config.urlProxyPac)
+    }
+
+    @Test
+    fun `parseConfigWithBlankUrlProxyPac returns null`() {
+        val json = """
+            {
+                "url-proxypac": "",
+                "run": {
+                    "cmd1": "ping -c 1 example.com"
+                }
+            }
+        """.trimIndent()
+
+        val config = parseBulkConfig(json)
+
+        assertNull(config.urlProxyPac)
+    }
+
+    @Test
+    fun `parseConfigWithUrlProxyPacAndOtherFields preserves all`() {
+        val json = """
+            {
+                "output-file": "/tmp/out.txt",
+                "timeout": 30,
+                "url-proxypac": "http://pac.example.org/auto.pac",
+                "run": {
+                    "cert": "checkcert -p 443 example.com",
+                    "sync": "google-timesync"
+                }
+            }
+        """.trimIndent()
+
+        val config = parseBulkConfig(json)
+
+        assertEquals("/tmp/out.txt", config.outputFile)
+        assertEquals(30_000L, config.timeoutMs)
+        assertEquals("http://pac.example.org/auto.pac", config.urlProxyPac)
+        assertEquals(2, config.commands.size)
+        assertEquals("checkcert -p 443 example.com", config.commands["cert"])
+        assertEquals("google-timesync", config.commands["sync"])
+    }
 }

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/GoogleTimeSyncViewModelTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/GoogleTimeSyncViewModelTest.kt
@@ -4,17 +4,37 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.github.mobilutils.ntp_dig_ping_more.settings.SettingsRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 
 /**
  * Unit tests for [GoogleTimeSyncViewModel] using MockK.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class GoogleTimeSyncViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
 
     private fun fakeSettingsRepository(): SettingsRepository = mockk<SettingsRepository>(relaxed = true).also {
         coEvery { it.timeoutSecondsFlow } returns flowOf(5)

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/ProxyResolverTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/ProxyResolverTest.kt
@@ -1,0 +1,172 @@
+package io.github.mobilutils.ntp_dig_ping_more
+
+import io.github.mobilutils.ntp_dig_ping_more.proxy.JsEngine
+import io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyResolver
+import io.github.mobilutils.ntp_dig_ping_more.settings.ProxyConfig
+import io.github.mobilutils.ntp_dig_ping_more.settings.SettingsRepository
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.net.Proxy
+
+/**
+ * Unit tests for [ProxyResolver].
+ *
+ * Tests PAC result parsing, caching, and fallback behaviour.
+ * Network I/O (PAC script fetching) and JS evaluation are mocked.
+ */
+class ProxyResolverTest {
+
+    private lateinit var settingsRepository: SettingsRepository
+    private lateinit var jsEngine: JsEngine
+    private lateinit var resolver: ProxyResolver
+
+    @Before
+    fun setup() {
+        settingsRepository = mockk(relaxed = true)
+        jsEngine = mockk(relaxed = true)
+        resolver = ProxyResolver(settingsRepository, jsEngine)
+    }
+
+    // ── parsePacResult tests ─────────────────────────────────────────────────
+
+    @Test
+    fun `parsePacResult returns null for DIRECT`() {
+        val result = resolver.parsePacResult("DIRECT")
+        assertNull(result)
+    }
+
+    @Test
+    fun `parsePacResult parses PROXY host port`() {
+        val result = resolver.parsePacResult("PROXY 10.0.0.1:8080")
+        assertNotNull(result)
+        assertEquals(Proxy.Type.HTTP, result!!.type())
+        assertTrue(result.address().toString().contains("10.0.0.1"))
+        assertTrue(result.address().toString().contains("8080"))
+    }
+
+    @Test
+    fun `parsePacResult parses SOCKS host port`() {
+        val result = resolver.parsePacResult("SOCKS 10.0.0.1:1080")
+        assertNotNull(result)
+        assertEquals(Proxy.Type.SOCKS, result!!.type())
+        assertTrue(result.address().toString().contains("10.0.0.1"))
+        assertTrue(result.address().toString().contains("1080"))
+    }
+
+    @Test
+    fun `parsePacResult parses SOCKS5 host port`() {
+        val result = resolver.parsePacResult("SOCKS5 10.0.0.1:1080")
+        assertNotNull(result)
+        assertEquals(Proxy.Type.SOCKS, result!!.type())
+    }
+
+    @Test
+    fun `parsePacResult handles fallback chain - uses first valid entry`() {
+        val result = resolver.parsePacResult("PROXY 10.0.0.1:8080; DIRECT")
+        assertNotNull(result)
+        assertEquals(Proxy.Type.HTTP, result!!.type())
+    }
+
+    @Test
+    fun `parsePacResult handles fallback chain - skips to DIRECT when proxy malformed`() {
+        val result = resolver.parsePacResult("PROXY invalid; DIRECT")
+        assertNull(result) // Falls through to DIRECT
+    }
+
+    @Test
+    fun `parsePacResult handles fallback chain - uses second proxy when first is malformed`() {
+        val result = resolver.parsePacResult("PROXY invalid; PROXY 10.0.0.1:3128")
+        assertNotNull(result)
+        assertEquals(Proxy.Type.HTTP, result!!.type())
+        assertTrue(result.address().toString().contains("10.0.0.1"))
+    }
+
+    @Test
+    fun `parsePacResult returns null for empty string`() {
+        val result = resolver.parsePacResult("")
+        assertNull(result)
+    }
+
+    @Test
+    fun `parsePacResult returns null for unknown directive`() {
+        val result = resolver.parsePacResult("UNKNOWN something")
+        assertNull(result)
+    }
+
+    @Test
+    fun `parsePacResult is case-insensitive for directives`() {
+        val result = resolver.parsePacResult("proxy 10.0.0.1:8080")
+        assertNotNull(result)
+        assertEquals(Proxy.Type.HTTP, result!!.type())
+    }
+
+    @Test
+    fun `parsePacResult handles extra whitespace`() {
+        val result = resolver.parsePacResult("  PROXY   10.0.0.1:8080  ;  DIRECT  ")
+        assertNotNull(result)
+        assertEquals(Proxy.Type.HTTP, result!!.type())
+    }
+
+    @Test
+    fun `parsePacResult rejects invalid port`() {
+        val result = resolver.parsePacResult("PROXY 10.0.0.1:99999")
+        assertNull(result) // port out of range, falls to implicit DIRECT
+    }
+
+    @Test
+    fun `parsePacResult rejects missing port`() {
+        val result = resolver.parsePacResult("PROXY 10.0.0.1")
+        assertNull(result)
+    }
+
+    // ── resolveProxy tests ───────────────────────────────────────────────────
+
+    @Test
+    fun `resolveProxy returns null when proxy is disabled`() = runTest {
+        coEvery { settingsRepository.proxyConfigFlow } returns flowOf(
+            ProxyConfig(enabled = false, pacUrl = "http://example.com/pac")
+        )
+
+        val result = resolver.resolveProxy("http://example.com")
+        assertNull(result)
+    }
+
+    @Test
+    fun `resolveProxy returns null when PAC URL is blank`() = runTest {
+        coEvery { settingsRepository.proxyConfigFlow } returns flowOf(
+            ProxyConfig(enabled = true, pacUrl = "")
+        )
+
+        val result = resolver.resolveProxy("http://example.com")
+        assertNull(result)
+    }
+
+    @Test
+    fun `resolveProxy returns null when JS engine throws`() = runTest {
+        coEvery { settingsRepository.proxyConfigFlow } returns flowOf(
+            ProxyConfig(enabled = true, pacUrl = "http://pac.example.com/proxy.pac")
+        )
+        every { jsEngine.evaluatePac(any(), any(), any()) } throws RuntimeException("JS error")
+
+        // The PAC fetch will fail (no real network), so resolver returns null
+        val result = resolver.resolveProxy("http://example.com")
+        assertNull(result)
+    }
+
+    // ── clearCache test ──────────────────────────────────────────────────────
+
+    @Test
+    fun `clearCache does not throw`() {
+        // Just verify it doesn't crash
+        resolver.clearCache()
+    }
+}

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/SettingsViewModelTest.kt
@@ -1,0 +1,264 @@
+package io.github.mobilutils.ntp_dig_ping_more
+
+import io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyResolver
+import io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyTestResult
+import io.github.mobilutils.ntp_dig_ping_more.settings.ProxyConfig
+import io.github.mobilutils.ntp_dig_ping_more.settings.SettingsRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [SettingsViewModel].
+ *
+ * Tests both the existing timeout functionality and the new proxy/PAC
+ * configuration features.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SettingsViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var settingsRepository: SettingsRepository
+    private lateinit var proxyResolver: ProxyResolver
+    private lateinit var viewModel: SettingsViewModel
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        settingsRepository = mockk(relaxed = true)
+        proxyResolver = mockk(relaxed = true)
+
+        coEvery { settingsRepository.timeoutSecondsFlow } returns flowOf(5)
+        coEvery { settingsRepository.proxyConfigFlow } returns flowOf(ProxyConfig())
+
+        viewModel = SettingsViewModel(settingsRepository, proxyResolver)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // ── Initialization ───────────────────────────────────────────────────────
+
+    @Test
+    fun `initial state has default timeout`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("5", viewModel.uiState.value.timeoutInput)
+    }
+
+    @Test
+    fun `initial state has proxy disabled`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertFalse(viewModel.uiState.value.proxyEnabled)
+    }
+
+    @Test
+    fun `initial state has empty PAC URL`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("", viewModel.uiState.value.proxyPacUrl)
+    }
+
+    @Test
+    fun `initial state loads persisted proxy config`() = runTest {
+        coEvery { settingsRepository.proxyConfigFlow } returns flowOf(
+            ProxyConfig(
+                enabled = true,
+                pacUrl = "http://proxy.corp.com/proxy.pac",
+                lastTested = 1000L,
+                lastTestResult = "✓ Success",
+            )
+        )
+
+        val vm = SettingsViewModel(settingsRepository, proxyResolver)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(vm.uiState.value.proxyEnabled)
+        assertEquals("http://proxy.corp.com/proxy.pac", vm.uiState.value.proxyPacUrl)
+        assertEquals(1000L, vm.uiState.value.proxyLastTested)
+        assertEquals("✓ Success", vm.uiState.value.proxyTestResult)
+    }
+
+    // ── Timeout ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `onTimeoutChange with valid value saves and clears error`() = runTest {
+        viewModel.onTimeoutChange("10")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("10", viewModel.uiState.value.timeoutInput)
+        assertFalse(viewModel.uiState.value.isError)
+        coVerify { settingsRepository.updateTimeout(10) }
+    }
+
+    @Test
+    fun `onTimeoutChange with out-of-range value sets error`() = runTest {
+        viewModel.onTimeoutChange("99")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.isError)
+    }
+
+    @Test
+    fun `revert restores last saved value`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onTimeoutChange("99") // out of range
+        assertTrue(viewModel.uiState.value.isError)
+
+        viewModel.revert()
+        assertEquals("5", viewModel.uiState.value.timeoutInput)
+        assertFalse(viewModel.uiState.value.isError)
+    }
+
+    // ── Proxy enable/disable ─────────────────────────────────────────────────
+
+    @Test
+    fun `onProxyEnabledChange updates state`() = runTest {
+        viewModel.onProxyEnabledChange(true)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.proxyEnabled)
+    }
+
+    @Test
+    fun `onProxyEnabledChange saves config`() = runTest {
+        viewModel.onProxyEnabledChange(true)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { settingsRepository.saveProxyConfig(any()) }
+    }
+
+    // ── PAC URL validation ───────────────────────────────────────────────────
+
+    @Test
+    fun `validatePacUrl accepts empty string`() {
+        assertNull(viewModel.validatePacUrl(""))
+    }
+
+    @Test
+    fun `validatePacUrl accepts valid HTTP URL`() {
+        assertNull(viewModel.validatePacUrl("http://proxy.corp.com/proxy.pac"))
+    }
+
+    @Test
+    fun `validatePacUrl accepts valid HTTPS URL`() {
+        assertNull(viewModel.validatePacUrl("https://proxy.corp.com/proxy.pac"))
+    }
+
+    @Test
+    fun `validatePacUrl rejects FTP URL`() {
+        val error = viewModel.validatePacUrl("ftp://proxy.corp.com/proxy.pac")
+        assertTrue(error != null && error.contains("http"))
+    }
+
+    @Test
+    fun `validatePacUrl rejects malformed URL`() {
+        val error = viewModel.validatePacUrl("not a url at all")
+        assertTrue(error != null && error.contains("Invalid"))
+    }
+
+    @Test
+    fun `validatePacUrl rejects URL without host`() {
+        val error = viewModel.validatePacUrl("http://")
+        // Depending on URL parser, this may be "Invalid" or "hostname"
+        assertTrue(error != null)
+    }
+
+    // ── PAC URL input with debounce ──────────────────────────────────────────
+
+    @Test
+    fun `onProxyPacUrlChange updates URL immediately`() = runTest {
+        viewModel.onProxyPacUrlChange("http://test.com/pac")
+        // URL should update immediately (before debounce)
+        assertEquals("http://test.com/pac", viewModel.uiState.value.proxyPacUrl)
+    }
+
+    @Test
+    fun `onProxyPacUrlChange clears error immediately while typing`() = runTest {
+        // First set an invalid URL and let debounce fire
+        viewModel.onProxyPacUrlChange("not a url")
+        testDispatcher.scheduler.advanceTimeBy(400)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(viewModel.uiState.value.proxyPacUrlError != null)
+
+        // Now start typing a new URL — error should clear immediately
+        viewModel.onProxyPacUrlChange("http://")
+        assertNull(viewModel.uiState.value.proxyPacUrlError)
+    }
+
+    @Test
+    fun `onProxyPacUrlChange clears proxy cache`() = runTest {
+        viewModel.onProxyPacUrlChange("http://new.pac.url")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Verify clearCache was called
+        io.mockk.verify { proxyResolver.clearCache() }
+    }
+
+    // ── Test Proxy ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `testProxy sets isTestingProxy while running`() = runTest {
+        coEvery { proxyResolver.testProxy() } returns
+            ProxyTestResult(success = true, message = "✓ HTTP 204", latencyMs = 50)
+
+        viewModel.testProxy()
+        // Should be in testing state
+        assertTrue(viewModel.uiState.value.isTestingProxy)
+
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Should be done testing
+        assertFalse(viewModel.uiState.value.isTestingProxy)
+    }
+
+    @Test
+    fun `testProxy updates result on success`() = runTest {
+        coEvery { proxyResolver.testProxy() } returns
+            ProxyTestResult(success = true, message = "✓ HTTP 204 via proxy (50ms)", latencyMs = 50)
+
+        viewModel.testProxy()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("✓ HTTP 204 via proxy (50ms)", viewModel.uiState.value.proxyTestResult)
+        assertTrue(viewModel.uiState.value.proxyLastTested > 0)
+    }
+
+    @Test
+    fun `testProxy updates result on failure`() = runTest {
+        coEvery { proxyResolver.testProxy() } returns
+            ProxyTestResult(success = false, message = "✗ Connection refused")
+
+        viewModel.testProxy()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("✗ Connection refused", viewModel.uiState.value.proxyTestResult)
+    }
+
+    @Test
+    fun `testProxy saves result to settings`() = runTest {
+        coEvery { proxyResolver.testProxy() } returns
+            ProxyTestResult(success = true, message = "✓ OK", latencyMs = 10)
+
+        viewModel.testProxy()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { settingsRepository.saveProxyConfig(any()) }
+    }
+}

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/TracerouteViewModelTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/TracerouteViewModelTest.kt
@@ -4,12 +4,19 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.github.mobilutils.ntp_dig_ping_more.settings.SettingsRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 
 /**
@@ -19,7 +26,20 @@ import org.junit.Test
  * be easily mocked. These tests focus on state management, input handlers,
  * history persistence, and job cancellation logic.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class TracerouteViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
 
     private fun fakeSettingsRepository(): SettingsRepository = mockk<SettingsRepository>(relaxed = true).also {
         coEvery { it.timeoutSecondsFlow } returns flowOf(5)
@@ -92,6 +112,10 @@ class TracerouteViewModelTest {
         val state = viewModel.uiState.value
         assertTrue(state.isRunning)
         assertTrue(state.outputLines.isEmpty())
+
+        // Cleanup: cancel the running traceroute to avoid leaked coroutines
+        viewModel.stopTraceroute()
+        advanceUntilIdle()
     }
 
     @Test
@@ -105,6 +129,10 @@ class TracerouteViewModelTest {
 
         // Should still be running, but no duplicate start
         assertTrue(viewModel.uiState.value.isRunning)
+
+        // Cleanup
+        viewModel.stopTraceroute()
+        advanceUntilIdle()
     }
 
     @Test
@@ -113,6 +141,7 @@ class TracerouteViewModelTest {
         viewModel.onHostChange("example.com")
         viewModel.startTraceroute()
         viewModel.stopTraceroute()
+        advanceUntilIdle()
 
         val state = viewModel.uiState.value
         assertFalse(state.isRunning)
@@ -230,6 +259,8 @@ class TracerouteViewModelTest {
 
         // onCleared() is protected and called by the framework when ViewModel is cleared
         // We can't directly test it, but we verify the ViewModel handles cancellation gracefully
+        viewModel.stopTraceroute()
+        advanceUntilIdle()
         assertTrue(true)
     }
 
@@ -243,6 +274,10 @@ class TracerouteViewModelTest {
         // Note: Actual hop probing runs on IO dispatcher and can't be easily mocked
         // This test verifies the initial state change
         assertTrue(viewModel.uiState.value.isRunning)
+
+        // Cleanup
+        viewModel.stopTraceroute()
+        advanceUntilIdle()
     }
 
     @Test
@@ -275,5 +310,9 @@ class TracerouteViewModelTest {
         // Output should be cleared when starting
         assertTrue(viewModel.uiState.value.outputLines.isEmpty())
         assertTrue(viewModel.uiState.value.isRunning)
+
+        // Cleanup
+        viewModel.stopTraceroute()
+        advanceUntilIdle()
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ navigationCompose = "2.8.9"
 dnsjava = "3.6.2"
 mockk = "1.13.12"
 coroutinesTest = "1.8.1"
+quickjs = "0.9.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -39,6 +40,7 @@ androidx-navigation-compose = { group = "androidx.navigation", name = "navigatio
 dnsjava = { group = "dnsjava", name = "dnsjava", version.ref = "dnsjava" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
+quickjs = { group = "app.cash.quickjs", name = "quickjs-android", version.ref = "quickjs" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/notes/20260503_Proxy PAC Settings_walkthrough.md
+++ b/notes/20260503_Proxy PAC Settings_walkthrough.md
@@ -1,0 +1,66 @@
+# Walkthrough: Proxy PAC Settings Integration
+
+## Overview
+
+Implemented a global Proxy PAC configuration section in the Settings screen. When enabled, HTTP traffic (`GoogleTimeSyncRepository`) and TLS traffic (`HttpsCertRepository`) are routed through the PAC-resolved proxy. PAC scripts are evaluated using QuickJS. All proxy logic is opt-in and backward-compatible.
+
+## Changes Made
+
+### Phase 1: Dependencies & Data Layer
+
+| File | Change |
+|------|--------|
+| [libs.versions.toml](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/gradle/libs.versions.toml) | Added `quickjs = "0.9.2"` version + `quickjs-android` library entry |
+| [build.gradle.kts](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/build.gradle.kts) | Added `implementation(libs.quickjs)` |
+| [ProxyConfig.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/settings/ProxyConfig.kt) | **[NEW]** Data class: `enabled`, `pacUrl`, `lastTested`, `lastTestResult` |
+| [SettingsDataStore.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/settings/SettingsDataStore.kt) | Added 4 proxy preference keys (`PROXY_ENABLED`, `PROXY_PAC_URL`, `PROXY_LAST_TESTED`, `PROXY_LAST_TEST_RESULT`) |
+| [SettingsRepository.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/settings/SettingsRepository.kt) | Added `proxyConfigFlow: Flow<ProxyConfig>` and `saveProxyConfig()` |
+
+### Phase 2: Core Proxy Engine (new `proxy/` package)
+
+| File | Purpose |
+|------|---------|
+| [JsEngine.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/JsEngine.kt) | **[NEW]** Interface for PAC script evaluation |
+| [QuickJsEngine.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/QuickJsEngine.kt) | **[NEW]** QuickJS implementation with PAC utility stubs |
+| [ProxyResolver.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/ProxyResolver.kt) | **[NEW]** Core resolver: PAC fetch, JS eval, result parsing, caching (5-min TTL), test connectivity |
+
+### Phase 3: Repository Integration
+
+| File | Change |
+|------|--------|
+| [GoogleTimeSyncRepository.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/GoogleTimeSyncRepository.kt) | Added `ProxyResolver?` constructor param; `openConnection(proxy)` when proxy resolved |
+| [HttpsCertRepository.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/HttpsCertRepository.kt) | Added `ProxyResolver?` constructor param + `createProxiedSSLSocket()` with HTTP CONNECT tunnel |
+
+> [!NOTE]
+> Both repositories use `ProxyResolver? = null` default, preserving full backward compatibility with existing code and tests.
+
+### Phase 4: Settings UI & ViewModel
+
+| File | Change |
+|------|--------|
+| [SettingsViewModel.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/SettingsViewModel.kt) | Extended with proxy state, `onProxyEnabledChange()`, `onProxyPacUrlChange()` (debounced), `testProxy()`, URL validation |
+| [SettingsScreen.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/SettingsScreen.kt) | Added "Proxy Configuration" card: Switch, PAC URL field, Test button, result display |
+| [GoogleTimeSyncViewModel.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/GoogleTimeSyncViewModel.kt) | Factory now injects `ProxyResolver` into repository |
+| [HttpsCertViewModel.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/HttpsCertViewModel.kt) | Factory now injects `ProxyResolver` into repository |
+
+### Phase 5: Testing
+
+| File | Tests | Status |
+|------|-------|--------|
+| [ProxyResolverTest.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/ProxyResolverTest.kt) | **[NEW]** 14 tests (PAC parsing, disabled/blank config, error handling) | ✅ All pass |
+| [SettingsViewModelTest.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/SettingsViewModelTest.kt) | **[NEW]** 17 tests (init, timeout, proxy toggle, URL validation, debounce, test proxy) | ✅ All pass |
+| [HttpsCertViewModelTest.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/HttpsCertViewModelTest.kt) | Existing 24 tests | ✅ All pass |
+
+## Verification
+
+| Check | Result |
+|-------|--------|
+| `./gradlew assembleDebug` | ✅ BUILD SUCCESSFUL |
+| `ProxyResolverTest` | ✅ 14/14 passed |
+| `SettingsViewModelTest` | ✅ 17/17 passed |
+| `HttpsCertViewModelTest` | ✅ 24/24 passed |
+| `GoogleTimeSyncViewModelTest` | ⚠️ Pre-existing Looper/Dispatchers.Main failures (unrelated) |
+| `TracerouteViewModelTest` | ⚠️ Pre-existing Looper failures (unrelated) |
+
+> [!WARNING]
+> `GoogleTimeSyncViewModelTest` and `TracerouteViewModelTest` have pre-existing failures caused by missing `Dispatchers.setMain()` setup. These are **not** regressions from this change.

--- a/notes/20260503_url-proxypac in bulkactions JSON Config_walkthrough.md
+++ b/notes/20260503_url-proxypac in bulkactions JSON Config_walkthrough.md
@@ -1,0 +1,61 @@
+# Walkthrough: `url-proxypac` in BulkActions JSON Config
+
+## Summary
+
+Added a new global field `"url-proxypac"` to the BulkActions JSON config file. When set, the HTTP-based pseudo-commands `checkcert` and `google-timesync` route their traffic through the proxy resolved by the PAC script. This is independent of the app's Settings proxy configuration and does not modify persisted settings.
+
+## Changes Made
+
+### Core Model & Parser
+
+#### [BulkActionsRepository.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt)
+- **`BulkConfig`** data class: Added `urlProxyPac: String? = null` field
+- **`BulkConfigParser.parse()`**: Extracts `"url-proxypac"` from JSON root object
+- **`BulkActionsRepository`**: 
+  - Added `bulkProxyResolver: ProxyResolver?` volatile field
+  - Added `setupProxyResolver(pacUrl)` / `clearProxyResolver()` public API
+  - `executeCommands()` automatically sets up/tears down the proxy resolver
+  - `executeCheckcert()`: Creates proxy-aware `HttpsCertRepository` when resolver is set
+  - `executeGoogleTimeSync()`: Creates proxy-aware `GoogleTimeSyncRepository` when resolver is set
+
+### Proxy Infrastructure
+
+#### [ProxyResolver.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/ProxyResolver.kt)
+- Added `staticPacUrl: String? = null` constructor parameter
+- Added `forStaticPacUrl()` companion factory method — creates a resolver that uses a PAC URL directly without reading from `SettingsRepository`
+- `resolveProxy()` now checks `staticPacUrl` first; only falls back to `SettingsRepository` when no static URL is set
+
+### ViewModel
+
+#### [BulkActionsViewModel.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsViewModel.kt)
+- Both `onLoadAndRun()` (ADB automation) and `onRunClicked()` (UI button) now call `repository.setupProxyResolver(config.urlProxyPac)` before execution and `repository.clearProxyResolver()` in their `finally` blocks
+
+### Tests
+
+#### [BulkConfigParserTest.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkConfigParserTest.kt)
+- Added 4 new test cases:
+  - `parseConfigWithUrlProxyPac returns value`
+  - `parseConfigWithoutUrlProxyPac returns null`
+  - `parseConfigWithBlankUrlProxyPac returns null`
+  - `parseConfigWithUrlProxyPacAndOtherFields preserves all`
+
+### Documentation & Example Config
+
+#### [README.md](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/README.md)
+- Documented `url-proxypac` in the Bulk Actions section with example JSON
+
+#### [blkacts_proxy_checkcert_timesync.json](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/notes/config-files_bulk-actions/blkacts_proxy_checkcert_timesync.json)
+- New example config file demonstrating `url-proxypac` usage
+
+## Design Decisions
+
+1. **Static PAC URL bypass**: Rather than writing the PAC URL to DataStore (which would overwrite the user's global proxy settings), the `ProxyResolver` was extended with a `staticPacUrl` parameter that bypasses `SettingsRepository` entirely.
+
+2. **Scoped lifecycle**: The proxy resolver is created before execution and cleaned up in `finally` blocks, ensuring no leaks across bulk action runs.
+
+3. **Only `checkcert` and `google-timesync`**: These are the only HTTP-based pseudo-commands that use `HttpsCertRepository` and `GoogleTimeSyncRepository` — both already accept an optional `ProxyResolver`. Other commands (`ping`, `dig`, `ntp`, `port-scan`, etc.) use raw sockets or process execution and don't support proxy routing.
+
+## Verification
+
+- **All unit tests pass** (full test suite: `./gradlew :app:testDebugUnitTest` — BUILD SUCCESSFUL)
+- **No regressions** in existing BulkConfigParser, BulkActionsViewModel, or any other test classes

--- a/notes/config-files_bulk-actions/blkacts_proxy_checkcert_timesync.json
+++ b/notes/config-files_bulk-actions/blkacts_proxy_checkcert_timesync.json
@@ -1,0 +1,9 @@
+{
+   "output-file": "~/files/blkacts_proxy_checkcert_timesync.txt",
+   "url-proxypac": "http://proxy.corp.com/proxy.pac",
+   "run": {
+     "checkcert_google": "checkcert -p 443 google.com",
+     "checkcert_example": "checkcert -p 443 example.com",
+     "google_timesync": "google-timesync"
+   }
+}


### PR DESCRIPTION
## Overview

Implemented a global Proxy PAC configuration section in the Settings screen. When enabled, HTTP traffic (`GoogleTimeSyncRepository`) and TLS traffic (`HttpsCertRepository`) are routed through the PAC-resolved proxy. PAC scripts are evaluated using QuickJS. All proxy logic is opt-in and backward-compatible.

## Changes Made

### Phase 1: Dependencies & Data Layer

| File | Change |
|------|--------|
| [libs.versions.toml](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/gradle/libs.versions.toml) | Added `quickjs = "0.9.2"` version + `quickjs-android` library entry |
| [build.gradle.kts](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/build.gradle.kts) | Added `implementation(libs.quickjs)` |
| [ProxyConfig.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/settings/ProxyConfig.kt) | **[NEW]** Data class: `enabled`, `pacUrl`, `lastTested`, `lastTestResult` |
| [SettingsDataStore.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/settings/SettingsDataStore.kt) | Added 4 proxy preference keys (`PROXY_ENABLED`, `PROXY_PAC_URL`, `PROXY_LAST_TESTED`, `PROXY_LAST_TEST_RESULT`) |
| [SettingsRepository.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/settings/SettingsRepository.kt) | Added `proxyConfigFlow: Flow<ProxyConfig>` and `saveProxyConfig()` |

### Phase 2: Core Proxy Engine (new `proxy/` package)

| File | Purpose |
|------|---------|
| [JsEngine.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/JsEngine.kt) | **[NEW]** Interface for PAC script evaluation |
| [QuickJsEngine.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/QuickJsEngine.kt) | **[NEW]** QuickJS implementation with PAC utility stubs |
| [ProxyResolver.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/ProxyResolver.kt) | **[NEW]** Core resolver: PAC fetch, JS eval, result parsing, caching (5-min TTL), test connectivity |

### Phase 3: Repository Integration

| File | Change |
|------|--------|
| [GoogleTimeSyncRepository.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/GoogleTimeSyncRepository.kt) | Added `ProxyResolver?` constructor param; `openConnection(proxy)` when proxy resolved |
| [HttpsCertRepository.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/HttpsCertRepository.kt) | Added `ProxyResolver?` constructor param + `createProxiedSSLSocket()` with HTTP CONNECT tunnel |

> [!NOTE]
> Both repositories use `ProxyResolver? = null` default, preserving full backward compatibility with existing code and tests.

### Phase 4: Settings UI & ViewModel

| File | Change |
|------|--------|
| [SettingsViewModel.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/SettingsViewModel.kt) | Extended with proxy state, `onProxyEnabledChange()`, `onProxyPacUrlChange()` (debounced), `testProxy()`, URL validation |
| [SettingsScreen.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/SettingsScreen.kt) | Added "Proxy Configuration" card: Switch, PAC URL field, Test button, result display |
| [GoogleTimeSyncViewModel.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/GoogleTimeSyncViewModel.kt) | Factory now injects `ProxyResolver` into repository |
| [HttpsCertViewModel.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/HttpsCertViewModel.kt) | Factory now injects `ProxyResolver` into repository |

### Phase 5: Testing

| File | Tests | Status |
|------|-------|--------|
| [ProxyResolverTest.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/ProxyResolverTest.kt) | **[NEW]** 14 tests (PAC parsing, disabled/blank config, error handling) | ✅ All pass |
| [SettingsViewModelTest.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/SettingsViewModelTest.kt) | **[NEW]** 17 tests (init, timeout, proxy toggle, URL validation, debounce, test proxy) | ✅ All pass |
| [HttpsCertViewModelTest.kt](file:///Users/enola/Workspace-gitmobilutils/android-ntp_dig_ping_more/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/HttpsCertViewModelTest.kt) | Existing 24 tests | ✅ All pass |

## Verification

| Check | Result |
|-------|--------|
| `./gradlew assembleDebug` | ✅ BUILD SUCCESSFUL |
| `ProxyResolverTest` | ✅ 14/14 passed |
| `SettingsViewModelTest` | ✅ 17/17 passed |
| `HttpsCertViewModelTest` | ✅ 24/24 passed |
| `GoogleTimeSyncViewModelTest` | ⚠️ Pre-existing Looper/Dispatchers.Main failures (unrelated) |
| `TracerouteViewModelTest` | ⚠️ Pre-existing Looper failures (unrelated) |

> [!WARNING]
> `GoogleTimeSyncViewModelTest` and `TracerouteViewModelTest` have pre-existing failures caused by missing `Dispatchers.setMain()` setup. These are **not** regressions from this change.
