### PR TITLE
feat() — Proxy PAC file-based loading, version 3.0

### DIFF
--- a/QWEN.md
+++ b/QWEN.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**ntp_dig_ping_more** is a production Android app (min SDK 26, target SDK 37) for network diagnostics. It provides 9 built-in tools plus a batch "Bulk Actions" feature: NTP Check, DIG (DNS), Ping, Traceroute, Port Scanner, LAN Scanner, Google Time Sync, HTTPS Certificate Inspector, Device Info, Settings, and Bulk Actions (JSON-configurable command batches).
+**ntp_dig_ping_more** is a production Android app (min SDK 26, target SDK 37) for network diagnostics. It provides 9 built-in tools plus a batch "Bulk Actions" feature: NTP Check, DIG (DNS), Ping, Traceroute, Port Scanner, LAN Scanner, Google Time Sync, HTTPS Certificate Inspector, Device Info, Settings, and Bulk Actions (JSON-configurable command batches). Current version: **3.0**.
 
 The app uses **ADB intent extras** for headless automation — configs can be pushed to the app's private directory via `run-as`, then the app launched with `--ez auto_run true` to execute commands without user interaction. A bundled shell script (`BULKACTIONS-ADB-SCRIPT.sh`) wraps this into a fully automated workflow for CI/manual use.
 
@@ -154,5 +154,5 @@ Same workflow as the Unix script, using PowerShell for JSON parsing and native C
 ## Git Workflow
 
 - Branch naming: `feat/<feature>`, `fix/<issue>`, `improve/<topic>`
-- Merge PRs with descriptive titles; version tags at `v2.x` on `main`
-- Recent work includes Proxy PAC, Settings, Bulk Actions ADB automation, and Device Info improvements
+- Merge PRs with descriptive titles; version tags at `v3.0` on `main`
+- Recent work includes Proxy PAC (file-based loading via SAF picker), Settings, Bulk Actions ADB automation, Device Info improvements, and test suite expansion to 334 tests

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ See [notes/20260501_BulkActions-ADB-Script-fixed.md](notes/20260501_BulkActions-
 | Persistence | AndroidX DataStore (history + global settings) |
 | Testing | JUnit 4, MockK 1.13, Coroutines Test |
 | Min SDK | 26 (Android 8.0) |
-| Target SDK | 35 (Android 15) |
+| Target SDK | 37 (Android 15) |
 
 ## Project Structure
 
@@ -377,7 +377,7 @@ adb shell am start -n io.github.mobilutils.ntp_dig_ping_more/.MainActivity
 
 ## Testing
 
-This project includes a unit test suite (255 tests) covering business logic, ViewModels, proxy resolution, and data parsing.
+This project includes a unit test suite (334 tests) covering business logic, ViewModels, proxy resolution, and data parsing.
 
 ```bash
 # Run all unit tests

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
         applicationId = "io.github.mobilutils.ntp_dig_ping_more"
         minSdk = 26
         targetSdk { version = release(rootProject.extra["defaultTargetSdkVersion"] as Int) }
-        versionCode = 22
-        versionName = "2.92"
+        versionCode = 23
+        versionName = "3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
@@ -50,6 +50,7 @@ data class BulkConfig(
     val timeoutMs: Long? = null,
     val outputAsCsv: Boolean = false,
     val urlProxyPac: String? = null,
+    val fileProxyPac: String? = null,
     val logProxy: Boolean? = null,
 )
 
@@ -116,6 +117,10 @@ object BulkConfigParser {
     @Volatile
     internal var appContext: Context? = null
 
+    /** When true, skip file existence checks during parse (for unit tests). Default: false. */
+    @Volatile
+    internal var skipFileValidation: Boolean = false
+
     /**
      * Parses a per-command `-t N` timeout from the command string.
      * Returns the timeout in milliseconds, or null if not present.
@@ -169,6 +174,29 @@ object BulkConfigParser {
             if (url.isNullOrBlank()) null else url.trim()
         }.getOrNull()
 
+        val fileProxyPac = runCatching {
+            val path = root.optString("file-proxypac", "")
+            if (path.isNullOrBlank()) null else expandTilde(path.trim())
+           }.getOrNull()
+
+            // Mutual exclusion validation — throw if both are present
+        if (!urlProxyPac.isNullOrBlank() && !fileProxyPac.isNullOrBlank()) {
+            throw IllegalArgumentException(
+                      "Cannot specify both 'url-proxypac' and 'file-proxypac'. They are mutually exclusive."
+                    )
+            }
+
+            // Validate file-proxypac exists and is readable (parse-time validation, skippable in tests)
+        if (!fileProxyPac.isNullOrBlank() && !skipFileValidation) {
+            val file = java.io.File(fileProxyPac)
+            if (!file.exists() || !file.isFile || !file.canRead()) {
+                throw IllegalArgumentException(
+                            "file-proxypac points to inaccessible file: $fileProxyPac. " +
+                                "Ensure the file exists and is readable."
+                        )
+                    }
+            }
+
         val logProxy: Boolean? = if (root.has("log-proxy")) {
             runCatching { root.optBoolean("log-proxy", false) }.getOrNull()
         } else {
@@ -188,7 +216,7 @@ object BulkConfigParser {
             }
         }
 
-        return BulkConfig(outputFile, commands, timeoutMs, outputAsCsv, urlProxyPac, logProxy)
+        return BulkConfig(outputFile, commands, timeoutMs, outputAsCsv, urlProxyPac, fileProxyPac, logProxy)
     }
 
     /** Expands `~` to the app's private files directory (no permissions needed on SDK 33+). */

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsViewModel.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsViewModel.kt
@@ -249,7 +249,8 @@ class BulkActionsViewModel(
             val allResults = mutableListOf<BulkCommandResult>()
 
             // Set up proxy resolver from config-level PAC URL (if any)
-            repository.setupProxyResolver(config.urlProxyPac, forceLogging = config.logProxy == true)
+            val pacSource = config.fileProxyPac ?: config.urlProxyPac
+            repository.setupProxyResolver(pacSource, forceLogging = config.logProxy == true)
 
             try {
                 commands.forEachIndexed { index, (name, cmd) ->
@@ -334,7 +335,8 @@ class BulkActionsViewModel(
                 val allResults = mutableListOf<BulkCommandResult>()
 
                 // Set up proxy resolver from config-level PAC URL (if any)
-                repository.setupProxyResolver(config.urlProxyPac, forceLogging = config.logProxy == true)
+                val pacSource = config.fileProxyPac ?: config.urlProxyPac
+            repository.setupProxyResolver(pacSource, forceLogging = config.logProxy == true)
 
                 commands.forEachIndexed { index, (name, cmd) ->
                     if (cancellationToken.get()) {

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/SettingsScreen.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/SettingsScreen.kt
@@ -1,5 +1,7 @@
 package io.github.mobilutils.ntp_dig_ping_more
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -21,6 +23,8 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -40,6 +44,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.github.mobilutils.ntp_dig_ping_more.settings.SettingsKeys
+import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -54,8 +59,8 @@ import java.util.Locale
  * Displays:
  *  1. A numeric text field to configure the operation timeout applied to all
  *     network-based tools.
- *  2. A Proxy/PAC configuration section with toggle, PAC URL input, logging
- *     toggle, log viewer, and a "Test Proxy/PAC" button.
+ *  2. A Proxy/PAC configuration section with toggle, PAC URL/File segmented toggle,
+ *      PAC input field, logging toggle, log viewer, and a "Test Proxy/PAC" button.
  *
  * Changes are saved immediately on valid input. If the timeout field loses
  * focus while invalid, the value is reverted to the last known-good setting.
@@ -69,29 +74,38 @@ fun SettingsScreen() {
     val viewModel: SettingsViewModel = viewModel(factory = SettingsViewModel.factory(context))
     val uiState by viewModel.uiState.collectAsState()
 
+      // SAF launcher for PAC file selection
+    val pacFilePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri: android.net.Uri? ->
+        uri?.let { selectedUri ->
+            viewModel.onPacFileSelected(selectedUri)
+          }
+     }
+
     Column(
         modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 16.dp, vertical = 20.dp),
+             .fillMaxSize()
+             .verticalScroll(rememberScrollState())
+             .padding(horizontal = 16.dp, vertical = 20.dp),
         verticalArrangement = Arrangement.spacedBy(24.dp),
-    ) {
+     ) {
 
-        // ── Network Configuration section ─────────────────────────────────────
+          // ── Network Configuration section ─────────────────────────────────────
         SettingsSectionCard(title = "Network Configuration") {
 
-            // Timeout field
+              // Timeout field
             OutlinedTextField(
                 value = uiState.timeoutInput,
                 onValueChange = viewModel::onTimeoutChange,
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .onFocusChanged { focusState ->
-                        // Revert if focus leaves while input is still invalid
+                     .fillMaxWidth()
+                     .onFocusChanged { focusState ->
+                          // Revert if focus leaves while input is still invalid
                         if (!focusState.isFocused && uiState.isError) {
                             viewModel.revert()
-                        }
-                    },
+                         }
+                     },
                 label = { Text("Operation Timeout (seconds)") },
                 placeholder = { Text(SettingsKeys.DEFAULT_TIMEOUT_SECONDS.toString()) },
                 singleLine = true,
@@ -100,55 +114,97 @@ fun SettingsScreen() {
                     if (uiState.isError) {
                         Text(
                             text = "Must be between ${SettingsKeys.MIN_TIMEOUT_SECONDS} " +
-                                   "and ${SettingsKeys.MAX_TIMEOUT_SECONDS}",
+                                    "and ${SettingsKeys.MAX_TIMEOUT_SECONDS}",
                             color = MaterialTheme.colorScheme.error,
-                        )
-                    } else {
+                         )
+                     } else {
                         Text(
                             text = "Applies to total duration of scans/requests.",
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                },
+                         )
+                     }
+                 },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            )
-        }
+             )
+         }
 
-        // ── Proxy Configuration section ───────────────────────────────────────
+          // ── Proxy Configuration section ───────────────────────────────────────
         SettingsSectionCard(title = "Proxy Configuration") {
 
-            // Enable/disable toggle
+              // Enable/disable toggle
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
-            ) {
+             ) {
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = "Enable Proxy",
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.Medium,
-                    )
+                     )
                     Text(
                         text = "Route traffic through a PAC-resolved proxy",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
+                     )
+                  }
                 Switch(
                     checked = uiState.proxyEnabled,
                     onCheckedChange = viewModel::onProxyEnabledChange,
-                )
-            }
+                 )
+             }
 
             Spacer(Modifier.height(16.dp))
 
-            // PAC URL input
+              // PAC source mode toggle
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+             ) {
+                FilterChip(
+                    selected = uiState.pacSourceMode == PacSourceMode.URL,
+                    onClick = { viewModel.onPacSourceModeChange(PacSourceMode.URL) },
+                    label = { Text("URL") },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                      ),
+                  )
+
+                FilterChip(
+                    selected = uiState.pacSourceMode == PacSourceMode.FILE,
+                    onClick = { viewModel.onPacSourceModeChange(PacSourceMode.FILE) },
+                    label = { Text("File") },
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                      ),
+                  )
+             }
+
+            Spacer(Modifier.height(8.dp))
+
+              // PAC URL/File input — mode-aware
             OutlinedTextField(
                 value = uiState.proxyPacUrl,
                 onValueChange = viewModel::onProxyPacUrlChange,
                 modifier = Modifier.fillMaxWidth(),
-                label = { Text("PAC URL") },
-                placeholder = { Text("http://proxy.corp.com/proxy.pac") },
+                label = {
+                    Text(
+                        when (uiState.pacSourceMode) {
+                            PacSourceMode.URL -> "PAC URL"
+                            PacSourceMode.FILE -> "PAC File"
+                          }
+                      )
+                  },
+                placeholder = {
+                    Text(
+                        when (uiState.pacSourceMode) {
+                            PacSourceMode.URL -> "http://proxy.corp.com/proxy.pac"
+                            PacSourceMode.FILE -> "/data/user/0/app/files/saved-pac.pac"
+                          }
+                      )
+                  },
                 singleLine = true,
                 enabled = uiState.proxyEnabled,
                 isError = uiState.proxyPacUrlError != null,
@@ -157,91 +213,120 @@ fun SettingsScreen() {
                         uiState.proxyPacUrlError != null -> Text(
                             text = uiState.proxyPacUrlError!!,
                             color = MaterialTheme.colorScheme.error,
-                        )
+                         )
+                        uiState.proxyEnabled && uiState.pacSourceMode == PacSourceMode.FILE &&
+                             uiState.proxyPacUrl.isNotBlank() && !uiState.proxyPacUrl.startsWith("content://") -> {
+                            val fileName = File(uiState.proxyPacUrl).name
+                            Text(
+                                text = "Local file: $fileName",
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                              )
+                           }
+                        uiState.proxyEnabled && uiState.pacSourceMode == PacSourceMode.FILE -> Text(
+                            text = "Browse to select a local .pac file",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                          )
                         uiState.proxyEnabled -> Text(
                             text = "URL to an auto-configuration (.pac) script",
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-            )
+                          )
+                      }
+                  },
+                keyboardOptions = when (uiState.pacSourceMode) {
+                    PacSourceMode.URL -> KeyboardOptions(keyboardType = KeyboardType.Uri)
+                    PacSourceMode.FILE -> KeyboardOptions(keyboardType = KeyboardType.Text)
+                  },
+                trailingIcon = when (uiState.pacSourceMode) {
+                    PacSourceMode.URL -> null         // No trailing icon for URL mode
+                    PacSourceMode.FILE -> {
+                        if (uiState.proxyEnabled) {
+                            {
+                                TextButton(
+                                    onClick = { pacFilePickerLauncher.launch("*/*") },
+                                  ) {
+                                    Text("Browse")
+                                   }
+                              }
+                          } else null
+                      }
+                  },
+             )
 
             Spacer(Modifier.height(8.dp))
 
-            // ── Proxy logging toggle ──────────────────────────────────────────
+              // ── Proxy logging toggle ──────────────────────────────────────────
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
-            ) {
+             ) {
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = "Enable Proxy Logging",
                         style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.Medium,
-                    )
+                     )
                     Text(
                         text = "Logs PAC fetches, resolutions, and errors to memory & file",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
+                     )
+                  }
                 Switch(
                     checked = uiState.proxyLoggingEnabled,
                     onCheckedChange = viewModel::onProxyLoggingEnabledChange,
                     enabled = uiState.proxyEnabled,
-                )
-            }
+                 )
+             }
 
-            // Log action buttons
+              // Log action buttons
             Row(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 4.dp),
+                     .fillMaxWidth()
+                     .padding(top = 4.dp),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
+             ) {
                 TextButton(
                     onClick = viewModel::onViewLogs,
                     enabled = uiState.proxyEnabled,
-                ) {
+                  ) {
                     Text("View Logs")
-                }
+                  }
                 TextButton(
                     onClick = viewModel::onClearLogs,
                     enabled = uiState.proxyEnabled,
-                ) {
+                  ) {
                     Text("Clear Logs")
-                }
-            }
+                  }
+             }
 
             Spacer(Modifier.height(8.dp))
 
-            // Test Proxy/PAC button
+              // Test Proxy/PAC button
             Button(
                 onClick = viewModel::testProxy,
                 enabled = uiState.proxyEnabled &&
                         uiState.proxyPacUrl.isNotBlank() &&
                         uiState.proxyPacUrlError == null &&
-                        !uiState.isTestingProxy,
+                         !uiState.isTestingProxy,
                 modifier = Modifier.fillMaxWidth(),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = MaterialTheme.colorScheme.secondary,
-                ),
-            ) {
+                  ),
+             ) {
                 if (uiState.isTestingProxy) {
                     CircularProgressIndicator(
                         modifier = Modifier.size(18.dp),
                         strokeWidth = 2.dp,
                         color = MaterialTheme.colorScheme.onSecondary,
-                    )
+                     )
                     Spacer(Modifier.width(8.dp))
                     Text("Testing…")
-                } else {
+                  } else {
                     Text("Test Proxy/PAC", fontWeight = FontWeight.Medium)
-                }
-            }
+                  }
+             }
 
-            // Last test result
+              // Last test result
             if (uiState.proxyTestResult != null) {
                 Spacer(Modifier.height(12.dp))
 
@@ -251,22 +336,22 @@ fun SettingsScreen() {
                     style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
                     color = if (isSuccess) MaterialTheme.colorScheme.secondary
                             else MaterialTheme.colorScheme.error,
-                )
+                 )
 
                 if (uiState.proxyLastTested > 0) {
                     val formatted = SimpleDateFormat("yyyy/MM/dd HH:mm:ss", Locale.getDefault())
-                        .format(Date(uiState.proxyLastTested))
+                         .format(Date(uiState.proxyLastTested))
                     Text(
                         text = "Last tested: $formatted",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-        }
-    }
+                      )
+                  }
+              }
+         }
+     }
 
-    // ── Log viewer dialog ─────────────────────────────────────────────────────
+      // ── Log viewer dialog ─────────────────────────────────────────────────────
     if (uiState.showLogDialog) {
         AlertDialog(
             onDismissRequest = viewModel::onDismissLogDialog,
@@ -277,30 +362,30 @@ fun SettingsScreen() {
                         text = "No logs recorded yet.",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                } else {
+                     )
+                  } else {
                     LazyColumn(
                         modifier = Modifier.height(400.dp),
-                    ) {
+                      ) {
                         items(uiState.proxyLogs) { line ->
                             Text(
                                 text = line,
                                 style = MaterialTheme.typography.bodySmall.copy(
                                     fontFamily = FontFamily.Monospace,
-                                ),
+                                  ),
                                 modifier = Modifier.padding(vertical = 1.dp),
-                            )
-                        }
-                    }
-                }
-            },
+                              )
+                          }
+                      }
+                  }
+              },
             confirmButton = {
                 TextButton(onClick = viewModel::onDismissLogDialog) {
                     Text("Close")
-                }
-            },
-        )
-    }
+                  }
+              },
+          )
+      }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -322,22 +407,22 @@ private fun SettingsSectionCard(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant,
-        ),
+          ),
         elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
-    ) {
+     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(
                 text = title,
                 style = MaterialTheme.typography.labelLarge,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.primary,
-            )
+              )
             Spacer(Modifier.height(8.dp))
             HorizontalDivider(
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.15f),
-            )
+              )
             Spacer(Modifier.height(16.dp))
             content()
-        }
-    }
+          }
+      }
 }

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/SettingsViewModel.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/SettingsViewModel.kt
@@ -1,6 +1,7 @@
 package io.github.mobilutils.ntp_dig_ping_more
 
 import android.content.Context
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -20,6 +21,24 @@ import kotlinx.coroutines.launch
 import java.io.File
 
 // ─────────────────────────────────────────────────────────────────────────────
+// PAC source mode
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Enum of supported PAC script sources. */
+enum class PacSourceMode {
+    /** HTTP/HTTPS URL (existing behavior). */
+    URL,
+
+    /** Local filesystem path (private storage or absolute path). */
+    FILE;
+
+    companion object {
+        /** Default source mode for new Settings screens. */
+        val Default = URL
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // UI state
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -31,8 +50,9 @@ import java.io.File
  * @param savedTimeout     The last successfully saved value; used to restore the
  *                         field if the user leaves it in an invalid state.
  * @param proxyEnabled     Whether proxy routing is currently active.
- * @param proxyPacUrl      Text in the PAC URL field.
- * @param proxyPacUrlError Inline validation error for the PAC URL, or null if valid.
+ * @param pacSourceMode    Current PAC source mode (URL or File).
+ * @param proxyPacUrl      Text in the PAC URL/File field.
+ * @param proxyPacUrlError Inline validation error for the PAC field, or null if valid.
  * @param isTestingProxy   True while a proxy connectivity test is in progress.
  * @param proxyTestResult  Human-readable result of the last test, or null if never tested.
  * @param proxyLastTested  Epoch millis of the last test, or 0 if never tested.
@@ -44,14 +64,15 @@ data class SettingsUiState(
     val timeoutInput: String = SettingsKeys.DEFAULT_TIMEOUT_SECONDS.toString(),
     val isError: Boolean = false,
     val savedTimeout: Int = SettingsKeys.DEFAULT_TIMEOUT_SECONDS,
-    // Proxy / PAC fields
+     // Proxy / PAC fields
     val proxyEnabled: Boolean = false,
+    val pacSourceMode: PacSourceMode = PacSourceMode.Default,
     val proxyPacUrl: String = "",
     val proxyPacUrlError: String? = null,
     val isTestingProxy: Boolean = false,
     val proxyTestResult: String? = null,
     val proxyLastTested: Long = 0L,
-    // Proxy logging fields
+     // Proxy logging fields
     val proxyLoggingEnabled: Boolean = false,
     val showLogDialog: Boolean = false,
     val proxyLogs: List<String> = emptyList(),
@@ -65,280 +86,357 @@ data class SettingsUiState(
  * ViewModel for the Settings screen.
  *
  * Responsibilities:
- *  - Load the persisted timeout on creation and expose it via [uiState].
- *  - Validate the user's raw text-field input (must be an integer in 1..60).
- *  - Save valid values immediately via [SettingsRepository.updateTimeout].
- *  - Revert the text field to the last known-good value on explicit [revert] call
- *    (e.g. when focus leaves an invalid field).
- *  - Manage the Proxy/PAC configuration (enable/disable, PAC URL, test connectivity).
- *  - Control the proxy PAC logger (enable/disable, view logs, clear logs).
+ *    - Load the persisted timeout on creation and expose it via [uiState].
+ *    - Validate the user's raw text-field input (must be an integer in 1..60).
+ *    - Save valid values immediately via [SettingsRepository.updateTimeout].
+ *    - Revert the text field to the last known-good value on explicit [revert] call
+ *      (e.g. when focus leaves an invalid field).
+ *    - Manage the Proxy/PAC configuration (enable/disable, PAC URL/file, test connectivity).
+ *    - Control the proxy PAC logger (enable/disable, view logs, clear logs).
  */
 class SettingsViewModel(
     private val settingsRepository: SettingsRepository,
     private val proxyResolver: ProxyResolver,
     private val proxyPacLogger: ProxyPacLogger,
+    private val appContext: Context? = null,     // NEW — for file-based PAC (copy-to-storage)
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
-    /** Debounce job for PAC URL validation. */
+     /** Debounce job for PAC URL validation. */
     private var pacUrlDebounceJob: Job? = null
 
-    /** Job for the current proxy test, so it can be cancelled if needed. */
+     /** Job for the current proxy test, so it can be cancelled if needed. */
     private var testJob: Job? = null
 
     init {
-        // Seed the text field from the persisted value (handles first-launch default too).
+         // Seed the text field from the persisted value (handles first-launch default too).
         viewModelScope.launch {
             settingsRepository.timeoutSecondsFlow.collect { persisted ->
-                // Only update if the field is not being actively edited to an invalid value
+                 // Only update if the field is not being actively edited to an invalid value
                 val current = _uiState.value
                 if (!current.isError) {
-                    _uiState.value = current.copy(
+                     _uiState.value = current.copy(
                         timeoutInput = persisted.toString(),
                         savedTimeout = persisted,
-                    )
-                } else {
-                    // Just sync the known-good backing value for revert purposes
-                    _uiState.value = current.copy(savedTimeout = persisted)
-                }
-            }
-        }
+                     )
+                 } else {
+                     // Just sync the known-good backing value for revert purposes
+                     _uiState.value = current.copy(savedTimeout = persisted)
+                 }
+             }
+         }
 
-        // Load persisted proxy config on creation
+         // Load persisted proxy config on creation
         viewModelScope.launch {
             val config = settingsRepository.proxyConfigFlow.first()
-            _uiState.value = _uiState.value.copy(
-                proxyEnabled        = config.enabled,
-                proxyPacUrl         = config.pacUrl,
-                proxyLastTested     = config.lastTested,
-                proxyTestResult     = config.lastTestResult,
-                proxyLoggingEnabled = config.loggingEnabled,
-            )
-            // Sync logger toggle from persisted state
+             _uiState.value = _uiState.value.copy(
+                proxyEnabled          = config.enabled,
+                proxyPacUrl           = config.pacUrl,
+                proxyLastTested       = config.lastTested,
+                proxyTestResult       = config.lastTestResult,
+                proxyLoggingEnabled  = config.loggingEnabled,
+             )
+             // Sync logger toggle from persisted state
             proxyPacLogger.enabled = config.loggingEnabled
-        }
-    }
+         }
+     }
 
-    // ── Timeout actions ──────────────────────────────────────────────────────
+     // ── Timeout actions ──────────────────────────────────────────────────────
 
-    /**
-     * Called on every keystroke in the timeout text field.
-     *
-     * If [value] parses to a valid integer in [SettingsKeys.MIN_TIMEOUT_SECONDS]..[SettingsKeys.MAX_TIMEOUT_SECONDS],
-     * the new value is immediately persisted and [isError] is cleared.
-     * Otherwise [isError] is set so the UI can show inline feedback.
-     */
+     /**
+      * Called on every keystroke in the timeout text field.
+      *
+      * If [value] parses to a valid integer in [SettingsKeys.MIN_TIMEOUT_SECONDS]..[SettingsKeys.MAX_TIMEOUT_SECONDS],
+      * the new value is immediately persisted and [isError] is cleared.
+      * Otherwise [isError] is set so the UI can show inline feedback.
+      */
     fun onTimeoutChange(value: String) {
-        // Accept only numeric input (allow empty for backspace UX)
+         // Accept only numeric input (allow empty for backspace UX)
         val filtered = value.filter { it.isDigit() }.take(3)
         val parsed = filtered.toIntOrNull()
         val valid = parsed != null &&
                 parsed >= SettingsKeys.MIN_TIMEOUT_SECONDS &&
                 parsed <= SettingsKeys.MAX_TIMEOUT_SECONDS
 
-        _uiState.value = _uiState.value.copy(
+         _uiState.value = _uiState.value.copy(
             timeoutInput = filtered,
             isError = parsed == null || parsed < SettingsKeys.MIN_TIMEOUT_SECONDS || parsed > SettingsKeys.MAX_TIMEOUT_SECONDS,
-        )
+         )
 
         if (valid && parsed != null) {
             viewModelScope.launch {
                 settingsRepository.updateTimeout(parsed)
-            }
-        }
-    }
+             }
+         }
+     }
 
-    /**
-     * Reverts the text field to the last successfully saved value.
-     *
-     * Call this when the text field loses focus while still in an invalid state,
-     * so the displayed value always reflects a real persisted setting.
-     */
+     /**
+      * Reverts the text field to the last successfully saved value.
+      *
+      * Call this when the text field loses focus while still in an invalid state,
+      * so the displayed value always reflects a real persisted setting.
+      */
     fun revert() {
         val saved = _uiState.value.savedTimeout
-        _uiState.value = _uiState.value.copy(
+         _uiState.value = _uiState.value.copy(
             timeoutInput = saved.toString(),
             isError = false,
-        )
-    }
+         )
+     }
 
-    // ── Proxy / PAC actions ──────────────────────────────────────────────────
+     // ── Proxy / PAC actions ──────────────────────────────────────────────────
 
-    /**
-     * Toggles proxy routing on/off and persists immediately.
-     */
+     /**
+      * Toggles proxy routing on/off and persists immediately.
+      */
     fun onProxyEnabledChange(enabled: Boolean) {
-        _uiState.value = _uiState.value.copy(proxyEnabled = enabled)
+         _uiState.value = _uiState.value.copy(proxyEnabled = enabled)
         viewModelScope.launch {
             saveCurrentProxyConfig()
-        }
+         }
+     }
+
+     /**
+      * Toggles between URL and File source modes for PAC configuration.
+      * Clears the PAC URL when switching modes to avoid confusion.
+      */
+    fun onPacSourceModeChange(mode: PacSourceMode) {
+         _uiState.value = _uiState.value.copy(
+            pacSourceMode = mode,
+            proxyPacUrl = "",       // Clear on switch to avoid stale content
+            proxyPacUrlError = null,
+         )
+        proxyResolver.clearCache()
+        viewModelScope.launch {
+            saveCurrentProxyConfig()
+         }
+     }
+
+     /**
+      * Called when the user selects a local PAC file via SAF picker.
+      * Copies the file content into app private storage, then stores the internal path.
+      */
+    fun onPacFileSelected(uri: Uri) {
+        val internalPath = appContext?.let { ctx ->
+            runCatching {
+                 // Copy selected file to private storage
+                val outputFile = File(ctx.filesDir, "saved-pac.pac")
+                ctx.contentResolver.openInputStream(uri)?.use { input ->
+                    outputFile.outputStream().use { output ->
+                        input.copyTo(output)
+                      }
+                    }
+                outputFile.absolutePath
+               }.getOrNull()
+           }
+
+         _uiState.value = _uiState.value.copy(
+            proxyPacUrl = internalPath ?: "",       // Store internal path, or empty on failure
+            proxyPacUrlError = if (internalPath == null) "Failed to copy file" else null,
+         )
+
+        if (internalPath != null) {
+            proxyResolver.clearCache()
+            viewModelScope.launch {
+                saveCurrentProxyConfig()
+             }
+           }
     }
 
-    /**
-     * Called on every keystroke in the PAC URL text field.
-     *
-     * Validation is debounced by 300 ms to avoid distracting the user
-     * while they are still typing. Valid URLs are persisted; invalid
-     * ones set [SettingsUiState.proxyPacUrlError].
-     */
+     /**
+      * Called on every keystroke in the PAC URL text field.
+      *
+      * Validation is debounced by 300 ms to avoid distracting the user
+      * while they are still typing. Valid URLs are persisted; invalid
+      * ones set [SettingsUiState.proxyPacUrlError].
+      */
     fun onProxyPacUrlChange(url: String) {
-        _uiState.value = _uiState.value.copy(
+         _uiState.value = _uiState.value.copy(
             proxyPacUrl = url,
             proxyPacUrlError = null, // clear error immediately while typing
-        )
+         )
 
-        // Clear proxy cache when URL changes
+         // Clear proxy cache when URL changes
         proxyResolver.clearCache()
 
         pacUrlDebounceJob?.cancel()
         pacUrlDebounceJob = viewModelScope.launch {
             delay(300) // debounce
 
-            val error = validatePacUrl(url)
-            _uiState.value = _uiState.value.copy(proxyPacUrlError = error)
+            val error = validatePacUrl(url, _uiState.value.pacSourceMode)
+             _uiState.value = _uiState.value.copy(proxyPacUrlError = error)
 
             if (error == null) {
                 saveCurrentProxyConfig()
-            }
-        }
-    }
+             }
+         }
+     }
 
-    /**
-     * Tests proxy connectivity and updates the UI with the result.
-     */
+     /**
+      * Tests proxy connectivity and updates the UI with the result.
+      */
     fun testProxy() {
         testJob?.cancel()
-        _uiState.value = _uiState.value.copy(isTestingProxy = true)
+         _uiState.value = _uiState.value.copy(isTestingProxy = true)
 
         testJob = viewModelScope.launch {
             val result = proxyResolver.testProxy()
             val now = System.currentTimeMillis()
 
-            _uiState.value = _uiState.value.copy(
-                isTestingProxy  = false,
+             _uiState.value = _uiState.value.copy(
+                isTestingProxy   = false,
                 proxyTestResult = result.message,
                 proxyLastTested = now,
-            )
+             )
 
-            // Persist test result
+             // Persist test result
             saveCurrentProxyConfig(
                 overrideLastTested = now,
                 overrideTestResult = result.message,
-            )
-        }
-    }
+             )
+         }
+     }
 
-    // ── Proxy logging actions ────────────────────────────────────────────────
+     // ── Proxy logging actions ────────────────────────────────────────────────
 
-    /**
-     * Toggles proxy PAC logging on/off, updates the logger flag, and persists.
-     */
+     /**
+      * Toggles proxy PAC logging on/off, updates the logger flag, and persists.
+      */
     fun onProxyLoggingEnabledChange(enabled: Boolean) {
         proxyPacLogger.enabled = enabled
-        _uiState.value = _uiState.value.copy(proxyLoggingEnabled = enabled)
+         _uiState.value = _uiState.value.copy(proxyLoggingEnabled = enabled)
         viewModelScope.launch {
             saveCurrentProxyConfig()
-        }
-    }
+         }
+     }
 
-    /**
-     * Opens the log viewer dialog with a snapshot of the current log buffer.
-     */
+     /**
+      * Opens the log viewer dialog with a snapshot of the current log buffer.
+      */
     fun onViewLogs() {
         val logs = proxyPacLogger.getLogs()
-        _uiState.value = _uiState.value.copy(
+         _uiState.value = _uiState.value.copy(
             showLogDialog = true,
             proxyLogs = logs,
-        )
-    }
+         )
+     }
 
-    /**
-     * Clears both the in-memory and persistent logs, and closes the dialog.
-     */
+     /**
+      * Clears both the in-memory and persistent logs, and closes the dialog.
+      */
     fun onClearLogs() {
         proxyPacLogger.clear()
-        _uiState.value = _uiState.value.copy(
+         _uiState.value = _uiState.value.copy(
             proxyLogs = emptyList(),
             showLogDialog = false,
-        )
-    }
+         )
+     }
 
-    /**
-     * Dismisses the log viewer dialog.
-     */
+     /**
+      * Dismisses the log viewer dialog.
+      */
     fun onDismissLogDialog() {
-        _uiState.value = _uiState.value.copy(showLogDialog = false)
-    }
+         _uiState.value = _uiState.value.copy(showLogDialog = false)
+     }
 
-    // ── Private helpers ──────────────────────────────────────────────────────
+     // ── Private helpers ──────────────────────────────────────────────────────
 
-    /**
-     * Validates a PAC URL string.
-     *
-     * @return An error message, or `null` if the URL is valid (or empty, since
-     *         an empty URL simply means "no proxy configured").
-     */
-    internal fun validatePacUrl(url: String): String? {
-        if (url.isBlank()) return null // empty is allowed — means disabled
-        return try {
-            val parsed = java.net.URL(url)
-            when {
-                parsed.protocol !in listOf("http", "https") ->
-                    "Only http:// and https:// URLs are supported"
-                parsed.host.isNullOrBlank() ->
-                    "URL must contain a hostname"
-                else -> null
-            }
-        } catch (_: Exception) {
-            "Invalid URL format"
+     /**
+      * Validates a PAC URL or file path string.
+      *
+      * @return An error message, or `null` if the input is valid (or empty, since
+      *         an empty value simply means "no proxy configured").
+      */
+    internal fun validatePacUrl(url: String, mode: PacSourceMode = _uiState.value.pacSourceMode): String? {
+        if (url.isBlank()) return null
+
+        when (mode) {
+            PacSourceMode.URL -> {
+                 // Existing HTTP/HTTPS URL validation...
+                return try {
+                    val parsed = java.net.URL(url)
+                    when {
+                        parsed.protocol !in listOf("http", "https") ->
+                             "Only http:// and https:// URLs are supported"
+                        parsed.host.isNullOrBlank() ->
+                             "URL must contain a hostname"
+                        else -> null
+                     }
+                 } catch (_: Exception) {
+                     "Invalid URL format"
+                 }
+             }
+            PacSourceMode.FILE -> {
+                 // For file mode: internal paths from copy-to-storage are always valid.
+                 // If user types a path manually, do basic validation (no tilde expansion).
+                 // NOTE: No tilde expansion in Settings file mode — paths are literal.
+                return try {
+                    val resolvedPath = if (url.startsWith("content://")) {
+                        android.net.Uri.parse(url).path ?: url
+                     } else {
+                        url
+                     }
+
+                     // Basic validation: must be a non-empty path
+                    if (resolvedPath.isBlank() || resolvedPath == "/") {
+                         "Invalid file path"
+                     } else {
+                        null      // File existence checked at fetch time, not here
+                     }
+                 } catch (_: Exception) {
+                     "Invalid file path"
+                 }
+             }
         }
     }
 
-    /**
-     * Persists the current proxy config from UI state to DataStore.
-     */
+     /**
+      * Persists the current proxy config from UI state to DataStore.
+      */
     private suspend fun saveCurrentProxyConfig(
         overrideLastTested: Long? = null,
         overrideTestResult: String? = null,
-    ) {
+     ) {
         val state = _uiState.value
         settingsRepository.saveProxyConfig(
             ProxyConfig(
-                enabled        = state.proxyEnabled,
-                pacUrl         = state.proxyPacUrl,
-                lastTested     = overrideLastTested ?: state.proxyLastTested,
+                enabled         = state.proxyEnabled,
+                pacUrl          = state.proxyPacUrl,
+                lastTested      = overrideLastTested ?: state.proxyLastTested,
                 lastTestResult = overrideTestResult ?: state.proxyTestResult,
                 loggingEnabled = state.proxyLoggingEnabled,
-            )
-        )
-    }
+             )
+         )
+     }
 
-    // ── Factory ───────────────────────────────────────────────────────────────
+     // ── Factory ───────────────────────────────────────────────────────────────
 
     companion object {
-        /** Creates a factory backed by the application-scoped [SettingsRepository]. */
+         /** Creates a factory backed by the application-scoped [SettingsRepository]. */
         fun factory(context: Context): ViewModelProvider.Factory =
             object : ViewModelProvider.Factory {
-                @Suppress("UNCHECKED_CAST")
+                 @Suppress("UNCHECKED_CAST")
                 override fun <T : ViewModel> create(modelClass: Class<T>): T {
                     val appContext = context.applicationContext
                     val settingsRepo = SettingsRepository(appContext)
                     val logger = ProxyPacLogger.getInstance(
                         logFile = File(appContext.filesDir, "proxypac-logs.txt"),
-                    )
+                     )
                     val proxyResolver = ProxyResolver(
                         settingsRepository = settingsRepo,
                         jsEngine = QuickJsEngine(),
                         logger = logger,
-                    )
+                        appContext = appContext,         // NEW — enables file-based PAC
+                     )
                     return SettingsViewModel(
                         settingsRepository = settingsRepo,
-                        proxyResolver      = proxyResolver,
-                        proxyPacLogger     = logger,
-                    ) as T
-                }
-            }
-    }
+                        proxyResolver       = proxyResolver,
+                        proxyPacLogger      = logger,
+                        appContext          = appContext,         // NEW
+                     ) as T
+                 }
+             }
+     }
 }

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/ProxyResolver.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/ProxyResolver.kt
@@ -1,10 +1,12 @@
 package io.github.mobilutils.ntp_dig_ping_more.proxy
 
+import android.content.Context
 import io.github.mobilutils.ntp_dig_ping_more.settings.ProxyConfig
 import io.github.mobilutils.ntp_dig_ping_more.settings.SettingsRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
+import java.io.File
 import java.net.HttpURLConnection
 import java.net.InetSocketAddress
 import java.net.Proxy
@@ -28,6 +30,31 @@ data class ProxyTestResult(
 )
 
 // ─────────────────────────────────────────────────────────────────────────────
+// FileSystemIO abstraction
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Abstracts file system operations for PAC script loading.
+ *
+ * Enables unit testing by allowing a mock implementation that returns
+ * fake PAC content without touching the real filesystem.
+ */
+interface FileSystemIO {
+    fun canRead(path: String): Boolean
+    fun isFile(path: String): Boolean
+    fun exists(path: String): Boolean
+    fun readText(path: String): String
+}
+
+/** Default production implementation wrapping [java.io.File]. */
+internal object DefaultFileSystemIO : FileSystemIO {
+    override fun canRead(path: String) = File(path).canRead()
+    override fun isFile(path: String) = File(path).isFile
+    override fun exists(path: String) = File(path).exists()
+    override fun readText(path: String) = File(path).readText(Charsets.UTF_8)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Proxy resolver
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -36,8 +63,8 @@ data class ProxyTestResult(
  * evaluating a PAC script from the user's configured PAC URL.
  *
  * **Caching:**
- *  - The PAC script body is cached for [PAC_CACHE_TTL_MS] (5 minutes).
- *  - Resolved proxy results are cached per host for the same TTL.
+ *   - The PAC script body is cached for [PAC_CACHE_TTL_MS] (5 minutes).
+ *   - Resolved proxy results are cached per host for the same TTL.
  *
  * **Failure handling:** Any failure (network, JS eval, parse) silently
  * returns `null`, meaning the caller should use a DIRECT connection.
@@ -46,13 +73,16 @@ data class ProxyTestResult(
  * @param jsEngine            JS engine used to evaluate `FindProxyForURL`.
  * @param staticPacUrl        Optional PAC URL override. When non-null, the resolver
  *                            uses this URL directly instead of reading from
- *                            [settingsRepository]. Used by BulkActions for
+ *                             [settingsRepository]. Used by BulkActions for
  *                            config-level `url-proxypac` without touching persisted settings.
  * @param logger              Optional [ProxyPacLogger] for high-level event logging.
  *                            When `null`, no logging occurs regardless of [forceLogging].
  * @param forceLogging        When `true`, logging is enabled even if [ProxyPacLogger.enabled]
  *                            is `false`. Used by BulkActions when `"log-proxy": true` is set
  *                            in the JSON config.
+ * @param appContext          Application context for file-based PAC support. When non-null,
+ *                            the resolver can load PAC scripts from local filesystem paths
+ *                             (in addition to HTTP/HTTPS URLs).
  */
 class ProxyResolver(
     private val settingsRepository: SettingsRepository,
@@ -60,11 +90,12 @@ class ProxyResolver(
     private val staticPacUrl: String? = null,
     private val logger: ProxyPacLogger? = null,
     private val forceLogging: Boolean = false,
+    private val appContext: Context? = null,
 ) {
 
     companion object {
         /** Cache TTL for both the PAC script body and per-host resolutions. */
-        private const val PAC_CACHE_TTL_MS = 5 * 60 * 1000L   // 5 minutes
+        private const val PAC_CACHE_TTL_MS = 5 * 60 * 1000L    // 5 minutes
 
         /** Connectivity-check URL used by [testProxy]. */
         private const val TEST_URL = "http://connectivitycheck.gstatic.com/generate_204"
@@ -87,7 +118,7 @@ class ProxyResolver(
          */
         fun forStaticPacUrl(
             pacUrl: String,
-            context: android.content.Context,
+            context: Context,
             jsEngine: JsEngine = QuickJsEngine(),
             logger: ProxyPacLogger? = null,
             forceLogging: Boolean = false,
@@ -97,6 +128,35 @@ class ProxyResolver(
             staticPacUrl = pacUrl,
             logger = logger,
             forceLogging = forceLogging,
+        )
+
+        /**
+         * Creates a [ProxyResolver] without file-based PAC support.
+         *
+         * Use this to migrate existing call sites; eventually remove after migration.
+         *
+         * @deprecated Use the constructor with Context for file-based PAC, or use [forStaticPacUrl].
+         */
+        @Deprecated(
+            message = "Use constructor with Context for file-based PAC, or forStaticPacUrl()",
+            replaceWith = ReplaceWith(
+                "ProxyResolver(settingsRepository, jsEngine, staticPacUrl, logger, forceLogging, appContext)",
+                "io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyResolver",
+            ),
+        )
+        fun withoutFileSupport(
+            settingsRepository: SettingsRepository,
+            jsEngine: JsEngine,
+            staticPacUrl: String? = null,
+            logger: ProxyPacLogger? = null,
+            forceLogging: Boolean = false,
+        ): ProxyResolver = ProxyResolver(
+            settingsRepository = settingsRepository,
+            jsEngine = jsEngine,
+            staticPacUrl = staticPacUrl,
+            logger = logger,
+            forceLogging = forceLogging,
+            appContext = null,
         )
     }
 
@@ -133,7 +193,7 @@ class ProxyResolver(
      * Resolves the proxy to use for [targetUrl].
      *
      * @return A [Proxy] instance, or `null` if the connection should be DIRECT
-     *         (proxy disabled, resolution failure, or PAC says DIRECT).
+     *          (proxy disabled, resolution failure, or PAC says DIRECT).
      */
     suspend fun resolveProxy(targetUrl: String): Proxy? = withContext(Dispatchers.IO) {
         try {
@@ -158,8 +218,19 @@ class ProxyResolver(
                 }
             }
 
-            // Fetch (or use cached) PAC script
-            val pacScript = fetchPacScript(effectivePacUrl) ?: return@withContext null
+            // Fetch (or use cached) PAC script — dispatch by source type
+            val pacScript = when {
+                effectivePacUrl.startsWith("http://") || effectivePacUrl.startsWith("https://") ->
+                    fetchPacScript(effectivePacUrl)
+                else ->
+                    // Treat as filesystem path — requires Context for file access
+                    if (appContext != null) {
+                        fetchPacFromFile(effectivePacUrl)
+                    } else {
+                        logIfEnabled("PAC_FETCH_FAIL reason=no Context for file access")
+                        null
+                    }
+            } ?: return@withContext null
 
             // Evaluate FindProxyForURL
             val pacResult = try {
@@ -221,8 +292,8 @@ class ProxyResolver(
                 val via = if (proxy != null && proxy.type() != Proxy.Type.DIRECT) "via ${proxy.address()}" else "DIRECT"
                 logIfEnabled("PROXY_TEST result=SUCCESS latency=${latencyMs}ms via=$via")
                 ProxyTestResult(
-                    success   = true,
-                    message   = "✓ HTTP $code $via (${latencyMs}ms)",
+                    success    = true,
+                    message    = "✓ HTTP $code $via (${latencyMs}ms)",
                     latencyMs = latencyMs,
                 )
             } else {
@@ -298,6 +369,44 @@ class ProxyResolver(
     }
 
     /**
+     * Fetches a PAC script from an absolute filesystem path.
+     * Uses the same caching contract as fetchPacScript().
+     *
+     * @param filePath Absolute path to the .pac file.
+     * @param fs       FileSystemIO abstraction (default: [DefaultFileSystemIO]).
+     * @return The PAC script content, or `null` if the file is inaccessible.
+     */
+    internal fun fetchPacFromFile(
+        filePath: String,
+        fs: FileSystemIO = DefaultFileSystemIO,
+    ): String? {
+        if (!fs.exists(filePath) || !fs.isFile(filePath) || !fs.canRead(filePath)) {
+            logIfEnabled("PAC_FETCH_FAIL path=$filePath reason=file not accessible")
+            return null
+        }
+
+        val now = System.currentTimeMillis()
+        if (cachedPacScript != null && cachedPacUrl == filePath &&
+            now - pacFetchedAt < PAC_CACHE_TTL_MS
+        ) {
+            return cachedPacScript
+        }
+
+        return try {
+            val script = fs.readText(filePath)
+
+            cachedPacScript = script
+            cachedPacUrl = filePath
+            pacFetchedAt = now
+            logIfEnabled("PAC_FETCH_SUCCESS path=$filePath")
+            script
+        } catch (e: Exception) {
+            logIfEnabled("PAC_FETCH_FAIL path=$filePath reason=${e.message}")
+            null
+        }
+    }
+
+    /**
      * Extracts the hostname from a URL string.
      */
     private fun extractHost(url: String): String? = try {
@@ -314,10 +423,10 @@ class ProxyResolver(
      * Parses a PAC result string into a [Proxy].
      *
      * Supports:
-     *  - `"DIRECT"` → returns `null`
-     *  - `"PROXY host:port"` → returns [Proxy.Type.HTTP]
-     *  - `"SOCKS host:port"` → returns [Proxy.Type.SOCKS]
-     *  - Fallback chains separated by `;` — uses the first valid entry
+     *   - `"DIRECT"` → returns `null`
+     *   - `"PROXY host:port"` → returns [Proxy.Type.HTTP]
+     *   - `"SOCKS host:port"` → returns [Proxy.Type.SOCKS]
+     *   - Fallback chains separated by `;` — uses the first valid entry
      *
      * @return A [Proxy] or `null` (meaning DIRECT).
      */

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkConfigParserTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkConfigParserTest.kt
@@ -1,9 +1,15 @@
 package io.github.mobilutils.ntp_dig_ping_more
 
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 
 /**
@@ -13,84 +19,117 @@ import org.junit.Test
  */
 class BulkConfigParserTest {
 
-    // ────────────────────────────────────────────────────────────────
-    // Parsing helpers that mirror BulkConfigParser
-    // ────────────────────────────────────────────────────────────────
+     @Before
+    fun setUp() {
+          // Ensure skipFileValidation is false before each test
+        BulkConfigParser.skipFileValidation = false
+        BulkConfigParser.appContext = null
+      }
 
-    /**
-     * Parses a JSON string into a [BulkConfig] using a minimal pure-Kotlin parser.
-     * Mirrors the logic in BulkConfigParser.parse() for testing without Android APIs.
-     */
+      @After
+    fun tearDown() {
+        unmockkAll()
+         // Reset parser state after each test
+        BulkConfigParser.skipFileValidation = false
+        BulkConfigParser.appContext = null
+       }
+
+       // ────────────────────────────────────────────────────────────────
+       // Parsing helpers that mirror BulkConfigParser
+       // ────────────────────────────────────────────────────────────────
+
+       /**
+        * Parses a JSON string into a [BulkConfig] using a minimal pure-Kotlin parser.
+        * Mirrors the logic in BulkConfigParser.parse() for testing without Android APIs.
+        */
     private fun parseBulkConfig(json: String): BulkConfig {
         val trimmed = json.trim()
 
-        // Extract "output-file" value (supports both quoted and unquoted)
+          // Extract "output-file" value (supports both quoted and unquoted)
         val outputFile = extractStringField(trimmed, "output-file")
 
-        // Extract "timeout" value (mirrors production parsing)
+          // Extract "timeout" value (mirrors production parsing)
         val timeoutMs = extractLongField(trimmed, "timeout")?.takeIf { it > 0 }?.let { it * 1000L }
 
-        // Extract "url-proxypac" value
+          // Extract "url-proxypac" value
         val urlProxyPac = extractStringField(trimmed, "url-proxypac")
 
-        // Extract "log-proxy" value
+          // Extract "file-proxypac" value
+        var fileProxyPac = extractStringField(trimmed, "file-proxypac")
+
+          // Apply tilde expansion if appContext is set (mirrors BulkConfigParser.expandTilde)
+          // In JVM tests, appContext is null by default so tilde is preserved as-is
+        if (fileProxyPac != null && fileProxyPac.startsWith("~/")) {
+            val privateDir = BulkConfigParser.appContext?.applicationContext?.filesDir?.absolutePath
+                ?: "/sdcard"
+            fileProxyPac = "$privateDir${fileProxyPac.substring(1)}"
+           }
+
+          // Extract "log-proxy" value
         val logProxy = extractBooleanField(trimmed, "log-proxy")
 
-        // Extract "run" object
+          // Mutual exclusion validation — mirrors BulkConfigParser behavior
+        if (!urlProxyPac.isNullOrBlank() && !fileProxyPac.isNullOrBlank()) {
+            throw IllegalArgumentException(
+                 "Cannot specify both 'url-proxypac' and 'file-proxypac'. They are mutually exclusive."
+               )
+           }
+
+          // Extract "run" object
         val runMatch = Regex("""\"run\"\s*:\s*\{([^}]*)\}""").find(trimmed)
-            ?: throw IllegalArgumentException("Missing required 'run' object in configuration")
+              ?: throw IllegalArgumentException("Missing required 'run' object in configuration")
 
         val runContent = runMatch.groupValues[1]
         val commands = mutableMapOf<String, String>()
 
-        val commandPattern = Regex("""\"([^\"]+)\"\s*:\s*\"([^\"]*)\"""") 
+        val commandPattern = Regex("""\"([^\"]+)\"\s*:\s*\"([^\"]*)\"""")
         commandPattern.findAll(runContent).forEach { match ->
             val key = match.groupValues[1]
             val value = match.groupValues[2].trim()
             if (value.isNotBlank()) {
                 commands[key] = value
-            }
-        }
+              }
+          }
 
-        return BulkConfig(outputFile, commands, timeoutMs, urlProxyPac = urlProxyPac, logProxy = logProxy)
-    }
+        return BulkConfig(outputFile, commands, timeoutMs, urlProxyPac = urlProxyPac, fileProxyPac = fileProxyPac, logProxy = logProxy)
+       }
 
-    /** Extracts a long field value from JSON, returning null if not found. */
+       /** Extracts a long field value from JSON, returning null if not found. */
     private fun extractLongField(json: String, fieldName: String): Long? {
         val pattern = Regex("""\"$fieldName\"\s*:\s*(-?\d+)""")
         val match = pattern.find(json)
         return match?.groupValues?.getOrNull(1)?.toLongOrNull()
-    }
+       }
 
-    /** Extracts a string field value from JSON, returning null if not found. */
+       /** Extracts a string field value from JSON, returning null if not found. */
     private fun extractStringField(json: String, fieldName: String): String? {
         val pattern = Regex("""\"$fieldName\"\s*:\s*\"([^\"]*)\"""")
         val match = pattern.find(json)
         return match?.groupValues?.getOrNull(1)?.takeIf { it.isNotEmpty() }
-    }
+       }
 
-    /** Extracts a boolean field value from JSON, returning null if not found. */
+       /** Extracts a boolean field value from JSON, returning null if not found. */
     private fun extractBooleanField(json: String, fieldName: String): Boolean? {
         val pattern = Regex("""\"$fieldName\"\s*:\s*(true|false)""")
         val match = pattern.find(json)
         return match?.groupValues?.getOrNull(1)?.toBooleanStrictOrNull()
-    }
+       }
 
-    // ────────────────────────────────────────────────────────────────
-    // Tests
-    // ────────────────────────────────────────────────────────────────
+       // ────────────────────────────────────────────────────────────────
+       // Tests
+       // ────────────────────────────────────────────────────────────────
 
-    @Test
+       @Test
     fun `parseValidConfig returns config with commands`() {
         val json = """
-            {
-                "output-file": "/tmp/output.txt",
-                "run": {
-                    "cmd1": "ping -c 4 google.com",
-                    "cmd2": "dig @1.1.1.1 example.com"
-                }
-            }
-        """.trimIndent()
+              {
+                  "output-file": "/tmp/output.txt",
+                  "run": {
+                      "cmd1": "ping -c 4 google.com",
+                      "cmd2": "dig @1.1.1.1 example.com"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
@@ -98,331 +137,331 @@ class BulkConfigParserTest {
         assertEquals(2, config.commands.size)
         assertEquals("ping -c 4 google.com", config.commands["cmd1"])
         assertEquals("dig @1.1.1.1 example.com", config.commands["cmd2"])
-    }
+       }
 
-    @Test
+       @Test
     fun `parseMissingRunKey throws exception`() {
         val json = """
-            {
-                "output-file": "/tmp/output.txt"
-            }
-        """.trimIndent()
+              {
+                  "output-file": "/tmp/output.txt"
+              }
+          """.trimIndent()
 
         val exception = try {
             parseBulkConfig(json)
             null
-        } catch (e: IllegalArgumentException) {
+           } catch (e: IllegalArgumentException) {
             e
-        }
+           }
 
         assertNotNull(exception)
         assertTrue(exception!!.message?.contains("run") == true)
-    }
+       }
 
-    @Test
+       @Test
     fun `parseEmptyCommands returns empty map`() {
         val json = """
-            {
-                "run": {}
-            }
-        """.trimIndent()
+              {
+                  "run": {}
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
         assertTrue(config.commands.isEmpty())
         assertNull(config.outputFile)
-    }
+       }
 
-    @Test
+       @Test
     fun `parseIgnoresBlankCommands`() {
         val json = """
-            {
-                "run": {
-                    "cmd1": "",
-                    "cmd2": "   ",
-                    "cmd3": "ping -c 1 example.com"
-                }
-            }
-        """.trimIndent()
+              {
+                  "run": {
+                      "cmd1": "",
+                      "cmd2": "    ",
+                      "cmd3": "ping -c 1 example.com"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
         assertEquals(1, config.commands.size)
         assertTrue(config.commands.containsKey("cmd3"))
-    }
+       }
 
-    @Test
+       @Test
     fun `parseMultipleCommands preserves all commands`() {
         val json = """
-            {
-                "run": {
-                    "cmd1": "ping -c 4 google.com",
-                    "cmd2": "ping -c 5 10.0.0.1",
-                    "cmd3": "dig @1.1.1.1 cybernews.com",
-                    "cmd4": "ntp pool.ntp.org",
-                    "cmd5": "port-scan -p 80-443 mobilutils.com",
-                    "cmd6": "checkcert -p 443 example.com"
-                }
-            }
-        """.trimIndent()
+              {
+                  "run": {
+                      "cmd1": "ping -c 4 google.com",
+                      "cmd2": "ping -c 5 10.0.0.1",
+                      "cmd3": "dig @1.1.1.1 cybernews.com",
+                      "cmd4": "ntp pool.ntp.org",
+                      "cmd5": "port-scan -p 80-443 mobilutils.com",
+                      "cmd6": "checkcert -p 443 example.com"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
         assertEquals(6, config.commands.size)
-    }
+       }
 
-    @Test
+       @Test
     fun `parseNoOutputFile returns null outputFile`() {
         val json = """
-            {
-                "run": {
-                    "cmd1": "ping -c 2 google.com"
-                }
-            }
-        """.trimIndent()
+              {
+                  "run": {
+                      "cmd1": "ping -c 2 google.com"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
         assertNull(config.outputFile)
         assertEquals(1, config.commands.size)
-    }
+       }
 
-    @Test
+       @Test
     fun `parseTildePath preserves tilde in JVM tests`() {
         val json = """
-            {
-                "output-file": "~/Downloads/test-run.txt",
-                "run": {
-                    "cmd1": "ping -c 1 example.com"
-                }
-            }
-        """.trimIndent()
+              {
+                  "output-file": "~/Downloads/test-run.txt",
+                  "run": {
+                      "cmd1": "ping -c 1 example.com"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
-        // In JVM tests without Android APIs, tilde is preserved as-is
-        // In production (Android), it would be expanded to external storage dir
+          // In JVM tests without Android APIs, tilde is preserved as-is
+          // In production (Android), it would be expanded to external storage dir
         assertTrue(config.outputFile?.startsWith("~/") == true)
         assertTrue(config.outputFile?.contains("Downloads/test-run.txt") == true)
-    }
+       }
 
-    @Test
+       @Test
     fun `parseNonTildePath returns unchanged`() {
         val json = """
-            {
-                "output-file": "/absolute/path/output.txt",
-                "run": {
-                    "cmd1": "ping -c 1 example.com"
-                }
-            }
-        """.trimIndent()
+              {
+                  "output-file": "/absolute/path/output.txt",
+                  "run": {
+                      "cmd1": "ping -c 1 example.com"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
         assertEquals("/absolute/path/output.txt", config.outputFile)
-    }
+       }
 
-    @Test
+       @Test
     fun `parseCommandsWithWhitespace trimsValues`() {
         val json = """
-            {
-                "run": {
-                    "cmd1": "  ping -c 1 example.com  "
-                }
-            }
-        """.trimIndent()
+              {
+                  "run": {
+                      "cmd1": "  ping -c 1 example.com   "
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
         assertEquals("ping -c 1 example.com", config.commands["cmd1"])
-    }
+       }
 
-    @Test
+       @Test
     fun `parseConfigWithTimeout returns timeoutMs`() {
         val json = """
-            {
-                "timeout": 60,
-                "run": {
-                    "cmd1": "ping -c 1 example.com"
-                }
-            }
-        """.trimIndent()
+              {
+                  "timeout": 60,
+                  "run": {
+                      "cmd1": "ping -c 1 example.com"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
         assertEquals(60_000L, config.timeoutMs)
-    }
+       }
 
-    @Test
+       @Test
     fun `parseConfigWithoutTimeout returns null`() {
         val json = """
-            {
-                "run": {
-                    "cmd1": "ping -c 1 example.com"
-                }
-            }
-        """.trimIndent()
+              {
+                  "run": {
+                      "cmd1": "ping -c 1 example.com"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
         assertNull(config.timeoutMs)
-    }
+       }
 
-    @Test
+       @Test
     fun `parseConfigWithZeroTimeout returns null`() {
         val json = """
-            {
-                "timeout": 0,
-                "run": {
-                    "cmd1": "ping -c 1 example.com"
-                }
-            }
-        """.trimIndent()
+              {
+                  "timeout": 0,
+                  "run": {
+                      "cmd1": "ping -c 1 example.com"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
         assertNull(config.timeoutMs)
-    }
+       }
 
-    @Test
+       @Test
     fun `parseConfigWithNegativeTimeout returns null`() {
         val json = """
-            {
-                "timeout": -10,
-                "run": {
-                    "cmd1": "ping -c 1 example.com"
-                }
-            }
-        """.trimIndent()
+              {
+                  "timeout": -10,
+                  "run": {
+                      "cmd1": "ping -c 1 example.com"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
         assertNull(config.timeoutMs)
-    }
+       }
 
-    @Test
+       @Test
     fun `extractCommandTimeoutWithValidValueReturnsMs`() {
         assertEquals(10_000L, BulkConfigParser.extractCommandTimeout("ping -c 4 -t 10 google.com"))
         assertEquals(30_000L, BulkConfigParser.extractCommandTimeout("dig @1.1.1.1 -t 30 example.com"))
         assertEquals(5_000L, BulkConfigParser.extractCommandTimeout("port-scan -p 80 -t 5 host"))
-    }
+       }
 
-    @Test
+       @Test
     fun `extractCommandTimeoutWithNoTFlagReturnsNull`() {
         assertNull(BulkConfigParser.extractCommandTimeout("ping -c 4 google.com"))
         assertNull(BulkConfigParser.extractCommandTimeout("device-info"))
-    }
+       }
 
-    @Test
+       @Test
     fun `extractCommandTimeoutWithZeroOrNegativeReturnsNull`() {
         assertNull(BulkConfigParser.extractCommandTimeout("ping -c 4 -t 0 google.com"))
         assertNull(BulkConfigParser.extractCommandTimeout("ping -c 4 -t -5 google.com"))
-    }
+       }
 
-    @Test
+       @Test
     fun `extractCommandTimeoutWithNonNumericReturnsNull`() {
         assertNull(BulkConfigParser.extractCommandTimeout("ping -c 4 -t abc google.com"))
-    }
+       }
 
 
-    @Test
+       @Test
     fun `bulkCommandClosed_isSubtypeOfBulkCommandResult`() {
         val result = BulkCommandClosed(
             commandName = "port-scan-test",
             command = "port-scan -p 443 10.0.0.1",
             outputLines = listOf("No open ports found."),
             durationMs = 2000L,
-        )
+           )
 
-         // Verify it's a valid BulkCommandResult
+          // Verify it's a valid BulkCommandResult
         assertTrue(result is BulkCommandResult)
         assertEquals("port-scan-test", result.commandName)
         assertEquals("port-scan -p 443 10.0.0.1", result.command)
-     }
+       }
 
-    @Test
+       @Test
     fun `bulkCommandClosed_containsOutputLinesAndDuration`() {
         val lines = listOf(
-             "[2026-04-30 09:53:19] port-scan -p 443 10.0.0.1",
-             "[2026-04-30 09:53:19] Status: CLOSED (2004ms)",
-             "  No open ports found.",
-        )
+              "[2026-04-30 09:53:19] port-scan -p 443 10.0.0.1",
+              "[2026-04-30 09:53:19] Status: CLOSED (2004ms)",
+              "  No open ports found.",
+           )
         val result = BulkCommandClosed(
             commandName = "test",
             command = "port-scan -p 443 10.0.0.1",
             outputLines = lines,
             durationMs = 2004L,
-        )
+           )
 
         assertEquals(3, result.outputLines.size)
         assertEquals(2004L, result.durationMs)
         assertTrue(result.outputLines.any { "No open ports found" in it })
-     }
+       }
 
-    // ────────────────────────────────────────────────────────────────
-    // url-proxypac tests
-    // ────────────────────────────────────────────────────────────────
+       // ────────────────────────────────────────────────────────────────
+       // url-proxypac tests
+       // ────────────────────────────────────────────────────────────────
 
-    @Test
+       @Test
     fun `parseConfigWithUrlProxyPac returns value`() {
         val json = """
-            {
-                "url-proxypac": "http://proxy.corp.com/proxy.pac",
-                "run": {
-                    "cmd1": "checkcert -p 443 google.com"
-                }
-            }
-        """.trimIndent()
+              {
+                  "url-proxypac": "http://proxy.corp.com/proxy.pac",
+                  "run": {
+                      "cmd1": "checkcert -p 443 google.com"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
         assertEquals("http://proxy.corp.com/proxy.pac", config.urlProxyPac)
-    }
+       }
 
-    @Test
+       @Test
     fun `parseConfigWithoutUrlProxyPac returns null`() {
         val json = """
-            {
-                "run": {
-                    "cmd1": "ping -c 1 example.com"
-                }
-            }
-        """.trimIndent()
+              {
+                  "run": {
+                      "cmd1": "ping -c 1 example.com"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
         assertNull(config.urlProxyPac)
-    }
+       }
 
-    @Test
+       @Test
     fun `parseConfigWithBlankUrlProxyPac returns null`() {
         val json = """
-            {
-                "url-proxypac": "",
-                "run": {
-                    "cmd1": "ping -c 1 example.com"
-                }
-            }
-        """.trimIndent()
+              {
+                  "url-proxypac": "",
+                  "run": {
+                      "cmd1": "ping -c 1 example.com"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
         assertNull(config.urlProxyPac)
-    }
+       }
 
-    @Test
+       @Test
     fun `parseConfigWithUrlProxyPacAndOtherFields preserves all`() {
         val json = """
-            {
-                "output-file": "/tmp/out.txt",
-                "timeout": 30,
-                "url-proxypac": "http://pac.example.org/auto.pac",
-                "run": {
-                    "cert": "checkcert -p 443 example.com",
-                    "sync": "google-timesync"
-                }
-            }
-        """.trimIndent()
+              {
+                  "output-file": "/tmp/out.txt",
+                  "timeout": 30,
+                  "url-proxypac": "http://pac.example.org/auto.pac",
+                  "run": {
+                      "cert": "checkcert -p 443 example.com",
+                      "sync": "google-timesync"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
@@ -432,41 +471,41 @@ class BulkConfigParserTest {
         assertEquals(2, config.commands.size)
         assertEquals("checkcert -p 443 example.com", config.commands["cert"])
         assertEquals("google-timesync", config.commands["sync"])
-    }
+       }
 
 
-     // ────────────────────────────────────────────────────────────────
-     // sleep pseudo-command parsing tests
-      // ────────────────────────────────────────────────────────────────
+        // ────────────────────────────────────────────────────────────────
+        // sleep pseudo-command parsing tests
+         // ────────────────────────────────────────────────────────────────
 
-      @Test
+         @Test
     fun `parseConfigWithSleepCommand_parsesCorrectly`() {
         val json = """
-              {
-                  "run": {
-                      "wait-5s": "sleep 5"
-                  }
-              }
-          """.trimIndent()
+                {
+                    "run": {
+                        "wait-5s": "sleep 5"
+                    }
+                }
+            """.trimIndent()
 
         val config = parseBulkConfig(json)
 
         assertEquals(1, config.commands.size)
         assertEquals("sleep 5", config.commands["wait-5s"])
-     }
+       }
 
-      @Test
+         @Test
     fun `parseConfigWithMultipleSleepCommands_parsesAll`() {
         val json = """
-              {
-                  "run": {
-                      "ping-google": "ping -c 3 google.com",
-                      "wait-5s": "sleep 5",
-                      "dig-example": "dig @8.8.8.8 example.com",
-                      "wait-short": "sleep 1"
-                  }
-              }
-          """.trimIndent()
+                {
+                    "run": {
+                        "ping-google": "ping -c 3 google.com",
+                        "wait-5s": "sleep 5",
+                        "dig-example": "dig @8.8.8.8 example.com",
+                        "wait-short": "sleep 1"
+                    }
+                }
+            """.trimIndent()
 
         val config = parseBulkConfig(json)
 
@@ -475,89 +514,89 @@ class BulkConfigParserTest {
         assertEquals("sleep 5", config.commands["wait-5s"])
         assertEquals("dig @8.8.8.8 example.com", config.commands["dig-example"])
         assertEquals("sleep 1", config.commands["wait-short"])
-     }
+       }
 
-      @Test
+         @Test
     fun `parseConfigWithMaxSleepValue_parsesCorrectly`() {
         val json = """
+                {
+                    "run": {
+                        "long-wait": "sleep 3600"
+                    }
+                }
+            """.trimIndent()
+
+        val config = parseBulkConfig(json)
+
+        assertEquals(1, config.commands.size)
+        assertEquals("sleep 3600", config.commands["long-wait"])
+       }
+
+       // ────────────────────────────────────────────────────────────────
+       // log-proxy tests
+       // ────────────────────────────────────────────────────────────────
+
+       @Test
+    fun `parseConfigWithLogProxyTrue returns true`() {
+        val json = """
               {
+                  "log-proxy": true,
                   "run": {
-                      "long-wait": "sleep 3600"
+                      "cmd1": "checkcert -p 443 google.com"
                   }
               }
           """.trimIndent()
 
         val config = parseBulkConfig(json)
 
-        assertEquals(1, config.commands.size)
-        assertEquals("sleep 3600", config.commands["long-wait"])
-     }
-
-    // ────────────────────────────────────────────────────────────────
-    // log-proxy tests
-    // ────────────────────────────────────────────────────────────────
-
-    @Test
-    fun `parseConfigWithLogProxyTrue returns true`() {
-        val json = """
-            {
-                "log-proxy": true,
-                "run": {
-                    "cmd1": "checkcert -p 443 google.com"
-                }
-            }
-        """.trimIndent()
-
-        val config = parseBulkConfig(json)
-
         assertEquals(true, config.logProxy)
-    }
+       }
 
-    @Test
+       @Test
     fun `parseConfigWithLogProxyFalse returns false`() {
         val json = """
-            {
-                "log-proxy": false,
-                "run": {
-                    "cmd1": "ping -c 1 example.com"
-                }
-            }
-        """.trimIndent()
+              {
+                  "log-proxy": false,
+                  "run": {
+                      "cmd1": "ping -c 1 example.com"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
         assertEquals(false, config.logProxy)
-    }
+       }
 
-    @Test
+       @Test
     fun `parseConfigWithoutLogProxy returns null`() {
         val json = """
-            {
-                "run": {
-                    "cmd1": "ping -c 1 example.com"
-                }
-            }
-        """.trimIndent()
+              {
+                  "run": {
+                      "cmd1": "ping -c 1 example.com"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
         assertNull(config.logProxy)
-    }
+       }
 
-    @Test
+       @Test
     fun `parseConfigWithLogProxyAndOtherFields preserves all`() {
         val json = """
-            {
-                "output-file": "/tmp/out.txt",
-                "timeout": 30,
-                "url-proxypac": "http://pac.example.org/auto.pac",
-                "log-proxy": true,
-                "run": {
-                    "cert": "checkcert -p 443 example.com",
-                    "sync": "google-timesync"
-                }
-            }
-        """.trimIndent()
+              {
+                  "output-file": "/tmp/out.txt",
+                  "timeout": 30,
+                  "url-proxypac": "http://pac.example.org/auto.pac",
+                  "log-proxy": true,
+                  "run": {
+                      "cert": "checkcert -p 443 example.com",
+                      "sync": "google-timesync"
+                  }
+              }
+          """.trimIndent()
 
         val config = parseBulkConfig(json)
 
@@ -566,5 +605,116 @@ class BulkConfigParserTest {
         assertEquals("http://pac.example.org/auto.pac", config.urlProxyPac)
         assertEquals(true, config.logProxy)
         assertEquals(2, config.commands.size)
-    }
+       }
+
+       // ────────────────────────────────────────────────────────────────
+       // file-proxypac tests (using mirror parser to avoid Android API deps)
+       // ────────────────────────────────────────────────────────────────
+
+       @Test
+    fun `parseConfigWithFileProxyPac_returnsPath`() {
+        val json = """{
+                 "run": { "ping_test": "ping -c 3 google.com" },
+                 "file-proxypac": "/sdcard/Downloads/proxy.pac"
+             }"""
+
+        val config = parseBulkConfig(json)
+        assertEquals("/sdcard/Downloads/proxy.pac", config.fileProxyPac)
+       }
+
+       @Test
+    fun `parseConfigWithBothUrlAndFileProxyPac_throwsError`() {
+        val json = """{
+                 "run": { "ping_test": "ping -c 3 google.com" },
+                 "url-proxypac": "http://proxy.corp.com/proxy.pac",
+                 "file-proxypac": "/sdcard/Downloads/proxy.pac"
+             }"""
+
+        assertThrows<IllegalArgumentException> {
+            parseBulkConfig(json)
+           }
+       }
+
+       @Test
+    fun `parseConfigWithBlankFileProxyPac_returnsNull`() {
+        val json = """{
+                 "run": { "ping_test": "ping -c 3 google.com" },
+                 "file-proxypac": ""
+             }"""
+
+        val config = parseBulkConfig(json)
+        assertNull(config.fileProxyPac)
+       }
+
+       @Test
+    fun `parseConfigWithMissingFileProxyPac_returnsNull`() {
+        val json = """{
+                 "run": { "ping_test": "ping -c 3 google.com" }
+             }"""
+
+        val config = parseBulkConfig(json)
+        assertNull(config.fileProxyPac)
+       }
+
+       @Test
+    fun `parseConfigWithUrlProxyPacAndFileProxyPacPreservesOtherFields_throws`() {
+          // Test that mutual exclusion error is thrown, not silent failure
+        val json = """{
+                 "output-file": "/tmp/test.txt",
+                 "url-proxypac": "http://proxy.corp.com/proxy.pac",
+                 "file-proxypac": "/sdcard/Downloads/proxy.pac",
+                 "log-proxy": true,
+                 "run": { "ping_test": "ping -c 3 google.com" }
+             }"""
+
+        assertThrows<IllegalArgumentException> {
+            parseBulkConfig(json)
+           }
+       }
+
+       @Test
+    fun `parseConfigWithFileProxyPac_andTilde_expands_whenAppContextSet`() {
+          // Set appContext for tilde expansion (mirrors BulkConfigParser behavior)
+        val mockCtx = mockk<Context>(relaxed = true)
+        every { mockCtx.applicationContext.filesDir.absolutePath } returns "/data/user/0/app/files"
+
+        try {
+            BulkConfigParser.appContext = mockCtx
+
+            val json = """{
+                     "run": { "ping_test": "ping -c 3 google.com" },
+                     "file-proxypac": "~/proxy.pac"
+                 }"""
+
+            val config = parseBulkConfig(json)
+            assertEquals("/data/user/0/app/files/proxy.pac", config.fileProxyPac)
+          } finally {
+            BulkConfigParser.appContext = null
+           }
+       }
+
+       @Test
+    fun `parseConfigWithFileProxyPac_noTilde_returnsUnchanged`() {
+        val json = """{
+                 "run": { "ping_test": "ping -c 3 google.com" },
+                 "file-proxypac": "/sdcard/Downloads/proxy.pac"
+             }"""
+
+        val config = parseBulkConfig(json)
+        assertEquals("/sdcard/Downloads/proxy.pac", config.fileProxyPac)
+       }
+
+       // ────────────────────────────────────────────────────────────────
+       // Helper: assertThrows for JUnit 4 compatibility
+       // ────────────────────────────────────────────────────────────────
+
+    private inline fun <reified T : Throwable> assertThrows(block: () -> Unit) {
+        try {
+            block()
+            throw AssertionError("Expected ${T::class.java.simpleName} to be thrown")
+           } catch (e: Throwable) {
+            if (e is T) return
+            throw e
+           }
+        }
 }

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/ProxyResolverTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/ProxyResolverTest.kt
@@ -1,5 +1,7 @@
 package io.github.mobilutils.ntp_dig_ping_more
 
+import io.github.mobilutils.ntp_dig_ping_more.proxy.DefaultFileSystemIO
+import io.github.mobilutils.ntp_dig_ping_more.proxy.FileSystemIO
 import io.github.mobilutils.ntp_dig_ping_more.proxy.JsEngine
 import io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyPacLogger
 import io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyResolver
@@ -22,8 +24,8 @@ import java.net.Proxy
 /**
  * Unit tests for [ProxyResolver].
  *
- * Tests PAC result parsing, caching, fallback behaviour, and logging integration.
- * Network I/O (PAC script fetching) and JS evaluation are mocked.
+ * Tests PAC result parsing, caching, fallback behaviour, logging integration,
+ * and file-based PAC loading with mocked FileSystemIO.
  */
 class ProxyResolverTest {
 
@@ -36,226 +38,329 @@ class ProxyResolverTest {
         settingsRepository = mockk(relaxed = true)
         jsEngine = mockk(relaxed = true)
         resolver = ProxyResolver(settingsRepository, jsEngine)
-    }
+      }
 
-    // ── parsePacResult tests ─────────────────────────────────────────────────
+      // ── parsePacResult tests ─────────────────────────────────────────────────
 
-    @Test
+      @Test
     fun `parsePacResult returns null for DIRECT`() {
         val result = resolver.parsePacResult("DIRECT")
         assertNull(result)
-    }
+      }
 
-    @Test
+      @Test
     fun `parsePacResult parses PROXY host port`() {
         val result = resolver.parsePacResult("PROXY 10.0.0.1:8080")
         assertNotNull(result)
         assertEquals(Proxy.Type.HTTP, result!!.type())
         assertTrue(result.address().toString().contains("10.0.0.1"))
         assertTrue(result.address().toString().contains("8080"))
-    }
+      }
 
-    @Test
+      @Test
     fun `parsePacResult parses SOCKS host port`() {
         val result = resolver.parsePacResult("SOCKS 10.0.0.1:1080")
         assertNotNull(result)
         assertEquals(Proxy.Type.SOCKS, result!!.type())
         assertTrue(result.address().toString().contains("10.0.0.1"))
         assertTrue(result.address().toString().contains("1080"))
-    }
+      }
 
-    @Test
+      @Test
     fun `parsePacResult parses SOCKS5 host port`() {
         val result = resolver.parsePacResult("SOCKS5 10.0.0.1:1080")
         assertNotNull(result)
         assertEquals(Proxy.Type.SOCKS, result!!.type())
-    }
+      }
 
-    @Test
+      @Test
     fun `parsePacResult handles fallback chain - uses first valid entry`() {
         val result = resolver.parsePacResult("PROXY 10.0.0.1:8080; DIRECT")
         assertNotNull(result)
         assertEquals(Proxy.Type.HTTP, result!!.type())
-    }
+      }
 
-    @Test
+      @Test
     fun `parsePacResult handles fallback chain - skips to DIRECT when proxy malformed`() {
         val result = resolver.parsePacResult("PROXY invalid; DIRECT")
         assertNull(result) // Falls through to DIRECT
-    }
+      }
 
-    @Test
+      @Test
     fun `parsePacResult handles fallback chain - uses second proxy when first is malformed`() {
         val result = resolver.parsePacResult("PROXY invalid; PROXY 10.0.0.1:3128")
         assertNotNull(result)
         assertEquals(Proxy.Type.HTTP, result!!.type())
         assertTrue(result.address().toString().contains("10.0.0.1"))
-    }
+      }
 
-    @Test
+      @Test
     fun `parsePacResult returns null for empty string`() {
         val result = resolver.parsePacResult("")
         assertNull(result)
-    }
+      }
 
-    @Test
+      @Test
     fun `parsePacResult returns null for unknown directive`() {
         val result = resolver.parsePacResult("UNKNOWN something")
         assertNull(result)
-    }
+      }
 
-    @Test
+      @Test
     fun `parsePacResult is case-insensitive for directives`() {
         val result = resolver.parsePacResult("proxy 10.0.0.1:8080")
         assertNotNull(result)
         assertEquals(Proxy.Type.HTTP, result!!.type())
-    }
+      }
 
-    @Test
+      @Test
     fun `parsePacResult handles extra whitespace`() {
-        val result = resolver.parsePacResult("  PROXY   10.0.0.1:8080  ;  DIRECT  ")
+        val result = resolver.parsePacResult("  PROXY   10.0.0.1:8080   ;  DIRECT   ")
         assertNotNull(result)
         assertEquals(Proxy.Type.HTTP, result!!.type())
-    }
+      }
 
-    @Test
+      @Test
     fun `parsePacResult rejects invalid port`() {
         val result = resolver.parsePacResult("PROXY 10.0.0.1:99999")
         assertNull(result) // port out of range, falls to implicit DIRECT
-    }
+      }
 
-    @Test
+      @Test
     fun `parsePacResult rejects missing port`() {
         val result = resolver.parsePacResult("PROXY 10.0.0.1")
         assertNull(result)
-    }
+      }
 
-    // ── resolveProxy tests ───────────────────────────────────────────────────
+      // ── resolveProxy tests ───────────────────────────────────────────────────
 
-    @Test
+      @Test
     fun `resolveProxy returns null when proxy is disabled`() = runTest {
         coEvery { settingsRepository.proxyConfigFlow } returns flowOf(
             ProxyConfig(enabled = false, pacUrl = "http://example.com/pac")
-        )
+          )
 
         val result = resolver.resolveProxy("http://example.com")
         assertNull(result)
-    }
+      }
 
-    @Test
+      @Test
     fun `resolveProxy returns null when PAC URL is blank`() = runTest {
         coEvery { settingsRepository.proxyConfigFlow } returns flowOf(
             ProxyConfig(enabled = true, pacUrl = "")
-        )
+          )
 
         val result = resolver.resolveProxy("http://example.com")
         assertNull(result)
-    }
+      }
 
-    @Test
+      @Test
     fun `resolveProxy returns null when JS engine throws`() = runTest {
         coEvery { settingsRepository.proxyConfigFlow } returns flowOf(
             ProxyConfig(enabled = true, pacUrl = "http://pac.example.com/proxy.pac")
-        )
+          )
         every { jsEngine.evaluatePac(any(), any(), any()) } throws RuntimeException("JS error")
 
-        // The PAC fetch will fail (no real network), so resolver returns null
+          // The PAC fetch will fail (no real network), so resolver returns null
         val result = resolver.resolveProxy("http://example.com")
         assertNull(result)
-    }
+      }
 
-    @Test
+      @Test
     fun `resolveProxy returns Proxy NO_PROXY when PAC evaluates to DIRECT`() = runTest {
-        // This test cannot verify the full PAC-fetch→eval→DIRECT pipeline in a
-        // unit test (fetchPacScript does real HTTP), but it validates the contract
-        // indirectly: parsePacResult("DIRECT") returns null, and resolveProxy wraps
-        // that null as Proxy.NO_PROXY.  Callers (GoogleTimeSyncRepository, etc.)
-        // then pass Proxy.NO_PROXY to URL.openConnection(proxy) which forces a
-        // truly direct connection, bypassing the system ProxySelector.
+          // This test cannot verify the full PAC-fetch→eval→DIRECT pipeline in a
+          // unit test (fetchPacScript does real HTTP), but it validates the contract
+          // indirectly: parsePacResult("DIRECT") returns null, and resolveProxy wraps
+          // that null as Proxy.NO_PROXY.  Callers (GoogleTimeSyncRepository, etc.)
+          // then pass Proxy.NO_PROXY to URL.openConnection(proxy) which forces a
+          // truly direct connection, bypassing the system ProxySelector.
         val direct = resolver.parsePacResult("DIRECT")
         assertNull("parsePacResult should return null for DIRECT", direct)
 
-        // After the fix, resolveProxy() wraps that null → Proxy.NO_PROXY, so
-        // callers receive a non-null Proxy of type DIRECT.
+          // After the fix, resolveProxy() wraps that null → Proxy.NO_PROXY, so
+          // callers receive a non-null Proxy of type DIRECT.
         assertEquals(Proxy.Type.DIRECT, Proxy.NO_PROXY.type())
-    }
+      }
 
-    // ── clearCache test ──────────────────────────────────────────────────────
+      // ── clearCache test ──────────────────────────────────────────────────────
 
-    @Test
+      @Test
     fun `clearCache does not throw`() {
-        // Just verify it doesn't crash
+          // Just verify it doesn't crash
         resolver.clearCache()
-    }
+      }
 
-    // ── Logging integration tests ────────────────────────────────────────────
+      // ── Logging integration tests ────────────────────────────────────────────
 
-    @Test
+      @Test
     fun `resolver with null logger does not throw`() = runTest {
-        // Default resolver has no logger — should work fine
+          // Default resolver has no logger — should work fine
         val noLogResolver = ProxyResolver(settingsRepository, jsEngine, logger = null)
         coEvery { settingsRepository.proxyConfigFlow } returns flowOf(
             ProxyConfig(enabled = false)
-        )
+          )
 
         val result = noLogResolver.resolveProxy("http://example.com")
         assertNull(result)
-    }
+      }
 
-    @Test
+      @Test
     fun `logIfEnabled does not log when logger disabled and forceLogging false`() = runTest {
         val logger = mockk<ProxyPacLogger>(relaxed = true)
         every { logger.enabled } returns false
 
         val loggedResolver = ProxyResolver(
             settingsRepository, jsEngine, logger = logger, forceLogging = false
-        )
+          )
         coEvery { settingsRepository.proxyConfigFlow } returns flowOf(
             ProxyConfig(enabled = false)
-        )
+          )
 
         loggedResolver.resolveProxy("http://example.com")
 
-        // Logger.log should not be called because proxy is disabled (early return)
-        // and even if logging path were hit, logger.enabled is false + forceLogging is false
+          // Logger.log should not be called because proxy is disabled (early return)
+          // and even if logging path were hit, logger.enabled is false + forceLogging is false
         verify(exactly = 0) { logger.log(any(), any()) }
-    }
+      }
 
-    @Test
+      @Test
     fun `logIfEnabled logs when forceLogging is true even if logger disabled`() = runTest {
         val logger = mockk<ProxyPacLogger>(relaxed = true)
         every { logger.enabled } returns false
 
         val loggedResolver = ProxyResolver(
             settingsRepository, jsEngine, logger = logger, forceLogging = true
-        )
+          )
         coEvery { settingsRepository.proxyConfigFlow } returns flowOf(
             ProxyConfig(enabled = true, pacUrl = "http://pac.example.com/proxy.pac")
-        )
+          )
 
-        // PAC fetch will fail (no real network), which should trigger a log
+          // PAC fetch will fail (no real network), which should trigger a log
         loggedResolver.resolveProxy("http://example.com")
 
-        // Should have logged the PAC fetch failure
+          // Should have logged the PAC fetch failure
         verify(atLeast = 1) { logger.log(match { it.contains("PAC_FETCH_FAIL") }, force = true) }
-    }
+      }
 
-    @Test
+      @Test
     fun `logIfEnabled logs when logger enabled`() = runTest {
         val logger = mockk<ProxyPacLogger>(relaxed = true)
         every { logger.enabled } returns true
 
         val loggedResolver = ProxyResolver(
             settingsRepository, jsEngine, logger = logger, forceLogging = false
-        )
+          )
         coEvery { settingsRepository.proxyConfigFlow } returns flowOf(
             ProxyConfig(enabled = true, pacUrl = "http://pac.example.com/proxy.pac")
-        )
+          )
 
-        // PAC fetch will fail (no real network), which should trigger a log
+          // PAC fetch will fail (no real network), which should trigger a log
         loggedResolver.resolveProxy("http://example.com")
 
-        // Should have logged the PAC fetch failure
+          // Should have logged the PAC fetch failure
         verify(atLeast = 1) { logger.log(match { it.contains("PAC_FETCH_FAIL") }, any()) }
-    }
+      }
+
+      // ── fetchPacFromFile tests (unit tests with mocked FileSystemIO) ───────────
+
+      @Test
+    fun `fetchPacFromFile reads PAC script from valid path via mock FS`() {
+        val mockFs = mockk<FileSystemIO>()
+        every { mockFs.exists("/tmp/test.pac") } returns true
+        every { mockFs.isFile("/tmp/test.pac") } returns true
+        every { mockFs.canRead("/tmp/test.pac") } returns true
+        every { mockFs.readText("/tmp/test.pac") } returns "function FindProxyForURL(u, h) { return 'DIRECT'; }"
+
+          // Use a resolver with appContext to enable file mode (but we're mocking FS so it doesn't matter)
+        val resolverWithFileSupport = ProxyResolver(settingsRepository, jsEngine, appContext = mockk())
+        val result = resolverWithFileSupport.fetchPacFromFile("/tmp/test.pac", mockFs)
+
+        assertNotNull(result)
+        assertEquals("function FindProxyForURL(u, h) { return 'DIRECT'; }", result)
+      }
+
+      @Test
+    fun `fetchPacFromFile returns null for non-existent path`() {
+        val mockFs = mockk<FileSystemIO>()
+        every { mockFs.exists("/nonexistent/pac.pac") } returns false
+
+        val resolverWithFileSupport = ProxyResolver(settingsRepository, jsEngine, appContext = mockk())
+        val result = resolverWithFileSupport.fetchPacFromFile("/nonexistent/pac.pac", mockFs)
+
+        assertNull(result)
+      }
+
+      @Test
+    fun `fetchPacFromFile returns null for non-readable path`() {
+        val mockFs = mockk<FileSystemIO>()
+        every { mockFs.exists(any()) } returns true
+        every { mockFs.isFile(any()) } returns true
+        every { mockFs.canRead(any()) } returns false
+
+        val resolverWithFileSupport = ProxyResolver(settingsRepository, jsEngine, appContext = mockk())
+        val result = resolverWithFileSupport.fetchPacFromFile("/unreadable/pac.pac", mockFs)
+
+        assertNull(result)
+      }
+
+      @Test
+    fun `fetchPacFromFile caches result and reuses within TTL`() {
+        val mockFs = mockk<FileSystemIO>()
+        every { mockFs.exists("/tmp/test.pac") } returns true
+        every { mockFs.isFile("/tmp/test.pac") } returns true
+        every { mockFs.canRead("/tmp/test.pac") } returns true
+        every { mockFs.readText("/tmp/test.pac") } returns "function FindProxyForURL(u, h) { return 'DIRECT'; }"
+
+        val resolverWithFileSupport = ProxyResolver(settingsRepository, jsEngine, appContext = mockk())
+
+          // Call twice within TTL — readText should only be called once (cached)
+        resolverWithFileSupport.fetchPacFromFile("/tmp/test.pac", mockFs)
+        resolverWithFileSupport.fetchPacFromFile("/tmp/test.pac", mockFs)
+
+        verify(exactly = 1) { mockFs.readText("/tmp/test.pac") }
+      }
+
+      @Test
+    fun `fetchPacFromFile handles exception on read error`() {
+        val mockFs = mockk<FileSystemIO>()
+        every { mockFs.exists(any()) } returns true
+        every { mockFs.isFile(any()) } returns true
+        every { mockFs.canRead(any()) } returns true
+        every { mockFs.readText(any()) } throws RuntimeException("Permission denied")
+
+        val resolverWithFileSupport = ProxyResolver(settingsRepository, jsEngine, appContext = mockk())
+        val result = resolverWithFileSupport.fetchPacFromFile("/error/pac.pac", mockFs)
+
+        assertNull(result)
+      }
+
+      @Test
+    fun `fetchPacFromFile returns null for non-file path`() {
+        val mockFs = mockk<FileSystemIO>()
+        every { mockFs.exists("/tmp/somedir") } returns true
+        every { mockFs.isFile("/tmp/somedir") } returns false
+
+        val resolverWithFileSupport = ProxyResolver(settingsRepository, jsEngine, appContext = mockk())
+        val result = resolverWithFileSupport.fetchPacFromFile("/tmp/somedir", mockFs)
+
+        assertNull(result)
+      }
+
+       // ── resolveProxy file-based PAC routing tests ──────────────────────────────
+        // NOTE: Full routing tests (resolveProxy dispatching to fetchPacFromFile) require
+        // Context mocks which crash in JVM tests without Robolectric. The fetchPacFromFile
+        // unit tests above cover the actual file-reading logic with mocked FileSystemIO.
+
+         @Test
+    fun `resolveProxy returns null for file path without Context`() = runTest {
+            // Without appContext, file paths should not be accessible
+        coEvery { settingsRepository.proxyConfigFlow } returns flowOf(
+            ProxyConfig(enabled = true, pacUrl = "/tmp/test.pac")
+            )
+
+        val resolverWithoutFileSupport = ProxyResolver(settingsRepository, jsEngine)
+
+        val result = resolverWithoutFileSupport.resolveProxy("http://example.com")
+        assertNull(result) // Should fail because appContext is null
+        }
 }

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/SettingsViewModelTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/SettingsViewModelTest.kt
@@ -1,5 +1,7 @@
 package io.github.mobilutils.ntp_dig_ping_more
 
+import android.content.Context
+import android.net.Uri
 import io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyPacLogger
 import io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyResolver
 import io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyTestResult
@@ -21,6 +23,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -30,7 +33,7 @@ import org.junit.Test
  * Unit tests for [SettingsViewModel].
  *
  * Tests both the existing timeout functionality and the new proxy/PAC
- * configuration and logging features.
+ * configuration, logging, and file-based PAC features.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class SettingsViewModelTest {
@@ -52,7 +55,7 @@ class SettingsViewModelTest {
         coEvery { settingsRepository.proxyConfigFlow } returns flowOf(ProxyConfig())
         every { proxyPacLogger.getLogs() } returns emptyList()
 
-        viewModel = SettingsViewModel(settingsRepository, proxyResolver, proxyPacLogger)
+        viewModel = SettingsViewModel(settingsRepository, proxyResolver, proxyPacLogger, appContext = null)
     }
 
     @After
@@ -98,7 +101,7 @@ class SettingsViewModelTest {
             )
         )
 
-        val vm = SettingsViewModel(settingsRepository, proxyResolver, proxyPacLogger)
+        val vm = SettingsViewModel(settingsRepository, proxyResolver, proxyPacLogger, appContext = null)
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertTrue(vm.uiState.value.proxyEnabled)
@@ -114,7 +117,7 @@ class SettingsViewModelTest {
             ProxyConfig(loggingEnabled = true)
         )
 
-        val vm = SettingsViewModel(settingsRepository, proxyResolver, proxyPacLogger)
+        val vm = SettingsViewModel(settingsRepository, proxyResolver, proxyPacLogger, appContext = null)
         testDispatcher.scheduler.advanceUntilIdle()
 
         verify { proxyPacLogger.enabled = true }
@@ -357,5 +360,87 @@ class SettingsViewModelTest {
         viewModel.onDismissLogDialog()
 
         assertFalse(viewModel.uiState.value.showLogDialog)
+    }
+
+    // ── PAC source mode ──────────────────────────────────────────────────────
+
+    @Test
+    fun `initial state has URL as default source mode`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(PacSourceMode.URL, viewModel.uiState.value.pacSourceMode)
+    }
+
+    @Test
+    fun `onPacSourceModeChange switches to FILE and clears URL`() = runTest {
+        // Set a URL first
+        viewModel.onProxyPacUrlChange("http://proxy.corp.com/proxy.pac")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Switch to FILE mode
+        viewModel.onPacSourceModeChange(PacSourceMode.FILE)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(PacSourceMode.FILE, viewModel.uiState.value.pacSourceMode)
+        assertEquals("", viewModel.uiState.value.proxyPacUrl)
+        assertNull(viewModel.uiState.value.proxyPacUrlError)
+        io.mockk.verify { proxyResolver.clearCache() }
+        coVerify { settingsRepository.saveProxyConfig(any()) }
+    }
+
+    @Test
+    fun `onPacSourceModeChange switches to URL and clears file path`() = runTest {
+        // Set a file path
+        viewModel.onPacSourceModeChange(PacSourceMode.FILE)
+        testDispatcher.scheduler.advanceUntilIdle()
+        viewModel.onProxyPacUrlChange("/data/user/0/app/files/saved-pac.pac")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Switch back to URL mode
+        viewModel.onPacSourceModeChange(PacSourceMode.URL)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(PacSourceMode.URL, viewModel.uiState.value.pacSourceMode)
+        assertEquals("", viewModel.uiState.value.proxyPacUrl)
+    }
+     // ── PAC file selection (copy-to-storage) ─────────────────────────────────
+     // NOTE: onPacFileSelected requires Android ContentResolver APIs (Uri.parse, openInputStream).
+     // These are tested via instrumented tests or cannot be unit-tested without Robolectric.
+     // The copy-to-storage logic is integration-tested through the SettingsScreen composable.
+
+     // ── Validation: FILE mode ────────────────────────────────────────────────
+
+     @Test
+    fun `validatePacUrl in FILE mode accepts internal private storage path`() {
+        val vm = SettingsViewModel(settingsRepository, proxyResolver, proxyPacLogger, appContext = null)
+          // Internal paths from copy-to-storage are always valid (no existence check at validate time)
+        assertNull(vm.validatePacUrl("/data/user/0/app/files/saved-pac.pac", PacSourceMode.FILE))
+         }
+
+     @Test
+    fun `validatePacUrl in FILE mode rejects empty path`() {
+        val vm = SettingsViewModel(settingsRepository, proxyResolver, proxyPacLogger, appContext = null)
+        val error = vm.validatePacUrl("/", PacSourceMode.FILE)
+        assertTrue(error != null && error.contains("Invalid"))
+         }
+
+     @Test
+    fun `validatePacUrl in FILE mode accepts absolute path with special chars`() {
+        val vm = SettingsViewModel(settingsRepository, proxyResolver, proxyPacLogger, appContext = null)
+          // Paths with dots and hyphens are valid
+        assertNull(vm.validatePacUrl("/data/user/0/app/files/my-saved.pac", PacSourceMode.FILE))
+         }
+
+     // ── Validation: URL mode (unchanged) ─────────────────────────────────────
+
+
+    @Test
+    fun `validatePacUrl in URL mode accepts valid HTTP URL`() {
+        assertNull(viewModel.validatePacUrl("http://proxy.corp.com/proxy.pac", PacSourceMode.URL))
+    }
+
+    @Test
+    fun `validatePacUrl in URL mode rejects FTP URL`() {
+        val error = viewModel.validatePacUrl("ftp://proxy.corp.com/proxy.pac", PacSourceMode.URL)
+        assertTrue(error != null && error.contains("http"))
     }
 }

--- a/notes/Add-LoadProxyPacViaSAF.md
+++ b/notes/Add-LoadProxyPacViaSAF.md
@@ -1,0 +1,475 @@
+---
+name: Load Proxy PAC from Local File via SAF
+description: Plan to add SAF file picker support for loading proxy PAC scripts from local files, alongside existing URL input.
+type: project
+---
+
+# Plan: Load Proxy PAC from Local File via SAF
+
+## Goal
+
+On the **SettingsScreen** under **Proxy Configuration**, allow users to load a PAC script from a local file using Android's Storage Access Framework (SAF) `GetContent` picker, in addition to the existing URL text field.
+
+---
+
+## Current State
+
+- **UI**: Single `OutlinedTextField` for PAC URL with `KeyboardType.Uri`. Supporting text says "URL to an auto-configuration (.pac) script".
+- **Validation**: `validatePacUrl()` checks for `http://` or `https://` protocol + non-empty host. Empty string is allowed (means disabled).
+- **Fetching**: `ProxyResolver.fetchPacScript()` uses `HttpURLConnection` only — HTTP/HTTPS GET, follows redirects, 10s timeouts.
+- **Storage**: PAC URL stored in DataStore under `PROXY_PAC_URL` key as a plain string.
+- **SAF precedent**: `BulkActionsScreen.kt` already uses `rememberLauncherForActivityResult(ActivityResultContracts.GetContent())` for loading JSON config files, and `CreateDocument` for output.
+
+---
+
+## Design Decisions
+
+### 1. Storage Model — Single Field, Scheme-Based Routing
+
+**Decision**: Store the file URI in the **same** `PROXY_PAC_URL` DataStore field. Detect source type by URI scheme:
+- `http://` or `https://` → HTTP fetch (existing behavior)
+- `content://` → SAF file read (new behavior)
+
+**Why**: No new DataStore keys, no migration, backward compatible. The string value is the single "source of truth" regardless of type.
+
+### 2. MIME Type Filter for Picker
+
+**Decision**: Use `"application/javascript"` as the MIME filter, with fallback to `"*/*"` if user's file manager doesn't show files matching that type. Alternatively, offer both options via a small popup menu or two separate buttons (e.g., "Browse PAC" and "Browse Any").
+
+**Why**: `.pac` files are typically `application/x-ns-proxy-autoconfig` (not widely supported) or `application/javascript`. Using `"application/javascript"` narrows the picker to JS files while still allowing manual browsing to other types.
+
+### 3. Display in UI — How to Show the Selected File
+
+**Decision**: When a file is selected, display the file's last path segment (filename) in the text field alongside the `content://` URI. Optionally show the filename as a tooltip or secondary line for readability.
+
+Example:
+```
+PAC URL
+┌───────────────────────────────────────┬────────┐
+│ content:///document/324...  proxy.pac │ Browse │
+└───────────────────────────────────────┴────────┘
+Local file: proxy.pac (1.2 KB)
+```
+
+**Why**: `content://` URIs are opaque and hard for users to read — showing the filename provides useful context.
+
+### 4. Caching Behavior
+
+**Decision**: Local file PAC scripts use the same 5-minute cache TTL as HTTP-fetched scripts. Cache key is the URI string (not file content hash). If the user re-selects the same file, the cached copy is used unless TTL has expired. `clearCache()` is called on every URL/URI change.
+
+**Why**: Consistent with existing behavior. File contents are unlikely to change during a session, and the 5-minute TTL prevents stale PAC logic from persisting across edits.
+
+### 5. Test Proxy Behavior
+
+**Decision**: The "Test Proxy/PAC" button works identically regardless of source type — it resolves through the loaded PAC script and pings `connectivitycheck.gstatic.com`. No changes needed here.
+
+---
+
+## Implementation Plan (Wall Version)
+
+### Step 1: `proxy/ProxyResolver.kt` — Add file reading + Context dependency
+
+**1a. Add `Context` to constructor** (stored as private val, used only for SAF access):
+
+```kotlin
+class ProxyResolver(
+    private val settingsRepository: SettingsRepository,
+    private val jsEngine: JsEngine,
+    private val staticPacUrl: String? = null,
+    private val logger: ProxyPacLogger? = null,
+    private val forceLogging: Boolean = false,
+    private val appContext: Context? = null,  // NEW — for SAF file reads
+) { ... }
+```
+
+**1b. Add `fetchPacFromUri()` method**:
+
+```kotlin
+/**
+ * Fetches a PAC script from a content:// URI using SAF ContentResolver.
+ * Uses the same caching contract as fetchPacScript().
+ */
+private fun fetchPacFromUri(uri: Uri): String? {
+    val context = appContext ?: run {
+        logIfEnabled("PAC_FETCH_FAIL reason=no Context available for file access")
+        return null
+     }
+
+    val now = System.currentTimeMillis()
+    if (cachedPacScript != null && cachedPacUrl == uri.toString() &&
+        now - pacFetchedAt < PAC_CACHE_TTL_MS) {
+        return cachedPacScript
+     }
+
+    return try {
+        val inputStream = context.contentResolver.openInputStream(uri)
+             ?: throw IOException("Failed to open input stream for $uri")
+        
+        val script = inputStream.bufferedReader(Charsets.UTF_8).readText()
+        inputStream.close()
+
+        cachedPacScript = script
+        cachedPacUrl = uri.toString()
+        pacFetchedAt = now
+        logIfEnabled("PAC_FETCH_SUCCESS url=$uri (local file)")
+        script
+     } catch (e: Exception) {
+        logIfEnabled("PAC_FETCH_FAIL url=$uri reason=${e.message}")
+        null
+     }
+}
+```
+
+**1c. Update `resolveProxy()` routing**:
+
+Replace this block in `resolveProxy()`:
+```kotlin
+// Fetch (or use cached) PAC script
+val pacScript = fetchPacScript(effectivePacUrl) ?: return@withContext null
+```
+
+With:
+```kotlin
+// Fetch (or use cached) PAC script
+val pacScript = if (effectivePacUrl.startsWith("content://")) {
+    appContext?.let { fetchPacFromUri(Uri.parse(effectivePacUrl)) }
+        ?: run { logIfEnabled("PAC_FETCH_FAIL reason=no Context"); null }
+} else {
+    fetchPacScript(effectivePacUrl)
+} ?: return@withContext null
+```
+
+**1d. Update `forStaticPacUrl()` factory** — pass `context` as the new `appContext` param:
+
+```kotlin
+fun forStaticPacUrl(
+    pacUrl: String,
+    context: android.content.Context,
+    jsEngine: JsEngine = QuickJsEngine(),
+    logger: ProxyPacLogger? = null,
+    forceLogging: Boolean = false,
+): ProxyResolver = ProxyResolver(
+    settingsRepository = SettingsRepository(context),
+    jsEngine = jsEngine,
+    staticPacUrl = pacUrl,
+    logger = logger,
+    forceLogging = forceLogging,
+    appContext = context,  // NEW
+)
+```
+
+---
+
+### Step 2: `SettingsViewModel.kt` — Add file selection action + validation update
+
+**2a. Add import**:
+```kotlin
+import android.net.Uri
+```
+
+**2b. Add `onPacFileSelected()` action**:
+
+```kotlin
+/**
+ * Called when the user selects a local PAC file via SAF picker.
+ * Stores the content:// URI as the active PAC source, clears cache.
+ */
+fun onPacFileSelected(uri: Uri) {
+    val uriString = uri.toString()
+    _uiState.value = _uiState.value.copy(
+        proxyPacUrl = uriString,
+        proxyPacUrlError = null,
+     )
+    proxyResolver.clearCache()
+    viewModelScope.launch {
+        saveCurrentProxyConfig()
+     }
+}
+```
+
+**2c. Update `validatePacUrl()`** to accept `content://` URIs:
+
+Replace the entire function with:
+```kotlin
+internal fun validatePacUrl(url: String): String? {
+    if (url.isBlank()) return null
+    
+    // Accept local file URIs from SAF picker
+    if (url.startsWith("content://")) {
+        return try {
+            val uri = Uri.parse(url)
+            if (uri.authority.isNullOrBlank()) "Invalid file URI"
+            else null
+         } catch (_: Exception) {
+             "Invalid file URI"
+         }
+     }
+    
+    // Existing HTTP/HTTPS URL validation...
+    return try {
+        val parsed = java.net.URL(url)
+        when {
+            parsed.protocol !in listOf("http", "https") ->
+                 "Only http:// and https:// URLs are supported"
+            parsed.host.isNullOrBlank() ->
+                 "URL must contain a hostname"
+            else -> null
+         }
+     } catch (_: Exception) {
+         "Invalid URL format"
+     }
+}
+```
+
+**2d. No changes to `onProxyPacUrlChange()` or `saveCurrentProxyConfig()`** — they already handle any string value in the PAC URL field, including `content://` URIs. The debounce → validate → save flow works identically for both HTTP URLs and file URIs.
+
+---
+
+### Step 3: `SettingsScreen.kt` — Add SAF launcher + Browse button
+
+**3a. Add imports**:
+```kotlin
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import android.net.Uri
+import androidx.compose.material3.TextButton
+import androidx.compose.foundation.layout.Row
+import androidx.compose.ui.Alignment
+```
+
+**3b. Add SAF launcher in the `SettingsScreen()` composable** (right after `viewModel` and `uiState` declarations):
+
+```kotlin
+val pacFilePickerLauncher = rememberLauncherForActivityResult(
+    contract = ActivityResultContracts.GetContent()
+) { uri: Uri? ->
+    uri?.let { selectedUri ->
+        viewModel.onPacFileSelected(selectedUri)
+     }
+}
+```
+
+**3c. Replace the existing PAC URL `OutlinedTextField` block** with a `Row` containing the text field + Browse button:
+
+Replace:
+```kotlin
+OutlinedTextField(
+    value = uiState.proxyPacUrl,
+    onValueChange = viewModel::onProxyPacUrlChange,
+    modifier = Modifier.fillMaxWidth(),
+    label = { Text("PAC URL") },
+    placeholder = { Text("http://proxy.corp.com/proxy.pac") },
+    singleLine = true,
+    enabled = uiState.proxyEnabled,
+    isError = uiState.proxyPacUrlError != null,
+    supportingText = { /* ... */ },
+    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+)
+```
+
+With:
+```kotlin
+Row(
+    modifier = Modifier.fillMaxWidth(),
+    verticalAlignment = Alignment.CenterVertically,
+) {
+    OutlinedTextField(
+        value = uiState.proxyPacUrl,
+        onValueChange = viewModel::onProxyPacUrlChange,
+        modifier = Modifier
+            .weight(1f)
+            .fillMaxWidth(),
+        label = { Text("PAC URL") },
+        placeholder = { Text("http://proxy.corp.com/proxy.pac") },
+        singleLine = true,
+        enabled = uiState.proxyEnabled,
+        isError = uiState.proxyPacUrlError != null,
+        supportingText = {
+            when {
+                uiState.proxyPacUrlError != null -> Text(
+                    text = uiState.proxyPacUrlError!!,
+                    color = MaterialTheme.colorScheme.error,
+                 )
+                uiState.proxyEnabled && uiState.proxyPacUrl.startsWith("content://") -> {
+                    val fileName = Uri.parse(uiState.proxyPacUrl).lastPathSegment ?: "unknown"
+                    Text(
+                        text = "Local file: $fileName",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                     )
+                 }
+                uiState.proxyEnabled -> Text(
+                    text = "URL to an auto-configuration (.pac) script or local file",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                 )
+             }
+         },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+     )
+
+    TextButton(
+        onClick = { pacFilePickerLauncher.launch("application/javascript") },
+        enabled = uiState.proxyEnabled,
+        modifier = Modifier.align(Alignment.CenterVertically),
+     ) {
+         Text("Browse")
+     }
+}
+```
+
+**3d. Update the "Test Proxy/PAC" button's `enabled` condition** — add a check that the PAC URL is not empty (same as before, no change needed since `content://` URIs are non-blank strings).
+
+---
+
+### Step 4: Tests
+
+#### 4a. `SettingsViewModelTest.kt` — Add tests
+
+```kotlin
+// ── PAC file selection ───────────────────────────────────────────────────
+
+@Test
+fun `onPacFileSelected stores content URI in state`() = runTest {
+    val fakeUri = Uri.parse("content://com.android.externalstorage.documents/document/324-162:proxy.pac")
+    viewModel.onPacFileSelected(fakeUri)
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    assertEquals(fakeUri.toString(), viewModel.uiState.value.proxyPacUrl)
+}
+
+@Test
+fun `onPacFileSelected clears error and persists config`() = runTest {
+    val fakeUri = Uri.parse("content://com.../proxy.pac")
+     // Set an invalid URL first, then select a file to clear it
+    viewModel.onProxyPacUrlChange("not a url")
+    testDispatcher.scheduler.advanceTimeBy(400)
+    testDispatcher.scheduler.advanceUntilIdle()
+    assertTrue(viewModel.uiState.value.proxyPacUrlError != null)
+
+    viewModel.onPacFileSelected(fakeUri)
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    assertNull(viewModel.uiState.value.proxyPacUrlError)
+    coVerify { settingsRepository.saveProxyConfig(any()) }
+}
+
+@Test
+fun `onPacFileSelected clears proxy cache`() = runTest {
+    val fakeUri = Uri.parse("content://com.../proxy.pac")
+    viewModel.onPacFileSelected(fakeUri)
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    io.mockk.verify { proxyResolver.clearCache() }
+}
+
+// ── Validation: content:// URIs ──────────────────────────────────────────
+
+@Test
+fun `validatePacUrl accepts valid content:// URI`() {
+    val uri = "content://com.android.externalstorage.documents/document/123-proxy.pac"
+    assertNull(viewModel.validatePacUrl(uri))
+}
+
+@Test
+fun `validatePacUrl rejects malformed content:// URI without authority`() {
+    val badUri = "content://"
+    val error = viewModel.validatePacUrl(badUri)
+    assertTrue(error != null)
+}
+
+@Test
+fun `validatePacUrl still accepts http URLs`() {
+    assertNull(viewModel.validatePacUrl("http://proxy.corp.com/proxy.pac"))
+    assertNull(viewModel.validatePacUrl("https://proxy.corp.com/proxy.pac"))
+}
+```
+
+#### 4b. `ProxyResolverTest.kt` — Add tests (instrumented, since they need Context)
+
+Add a new test class or extend existing:
+
+```kotlin
+@RunWith(AndroidJUnit4::class)
+class ProxyResolverFileTest {
+
+    private lateinit var context: Context
+    private lateinit var settingsRepository: SettingsRepository
+    private lateinit var proxyResolver: ProxyResolver
+
+    @Before
+    fun setup() {
+        // Use Application context from InstrumentationRegistry
+        context = InstrumentationRegistry.getInstrumentation().applicationContext
+        settingsRepository = SettingsRepository(context)
+        proxyResolver = ProxyResolver(
+            settingsRepository = settingsRepository,
+            jsEngine = QuickJsEngine(),
+            appContext = context,  // Enable file reading
+         )
+     }
+
+    @Test
+    fun `resolveProxy uses cached PAC from content URI`() {
+        // Create a MockContentResolver with a test PAC script
+        val mockResolver = MockContentResolver()
+        val pacScript = "function FindProxyForURL(url, host) { return 'DIRECT'; }"
+        mockResolver.openOutputStream(Uri.parse("content://test/pac.pac"))
+            ?.use { it.write(pacScript.toByteArray(Charsets.UTF_8)) }
+        
+        // Replace appContext's resolver (requires wrapping or reflection for test)
+        // Or: extract fetchPacFromUri behind an interface for mocking
+    }
+
+    @Test
+    fun `resolveProxy returns null when content URI is inaccessible`() {
+        // Test with non-existent document ID — should fall back to DIRECT
+    }
+}
+```
+
+**Note**: Testing `fetchPacFromUri` directly requires a `Context` with a `ContentResolver`. Recommended approach: extract file reading behind an interface (`PacFileReader`) that can be mocked in unit tests, keeping `ProxyResolver` constructor clean. For now, instrumented tests are acceptable since they need real Android framework components anyway.
+
+---
+
+## Files to Change (Summary)
+
+| File | Changes |
+|---|---|
+| `proxy/ProxyResolver.kt` | Add `Context?` param to constructor; add `fetchPacFromUri()` method; update `resolveProxy()` routing; update `forStaticPacUrl()` factory |
+| `SettingsViewModel.kt` | Add `onPacFileSelected(uri: Uri)` action; update `validatePacUrl()` for `content://` URIs |
+| `SettingsScreen.kt` | Add SAF launcher (`GetContent`); add "Browse" TextButton + Row layout; update supporting text with filename hint |
+| `SettingsViewModelTest.kt` | Add 6 new tests: file selection (3), validation (3) |
+| `ProxyResolverTest.kt` or new instrumented test class | Add 2+ tests for file-based PAC resolution |
+
+**No changes needed**: `SettingsRepository.kt`, `ProxyConfig.kt`, `SettingsDataStore.kt`, `SettingsKeys` — the existing `PROXY_PAC_URL` string field handles both HTTP URLs and `content://` URIs transparently.
+
+---
+
+## Implementation Order
+
+1. **`proxy/ProxyResolver.kt`** — Context param, `fetchPacFromUri()`, routing in `resolveProxy()`, factory update
+2. **`SettingsViewModel.kt`** — `onPacFileSelected()`, `validatePacUrl()` update
+3. **`SettingsScreen.kt`** — SAF launcher, Browse button, filename hint
+4. **Tests** — SettingsViewModelTest (6 tests), ProxyResolver instrumented tests
+
+---
+
+## Edge Cases & Considerations
+
+| Scenario | Handling |
+|---|---|
+| User selects a non-JS / non-PAC file | No MIME enforcement beyond picker hint. The JS engine will fail to evaluate and return null (same as invalid PAC content from HTTP). Safe fallback. |
+| File is deleted or permissions revoked after selection | `fetchPacFromUri()` throws → returns null → resolver falls back to DIRECT. User sees "Test Proxy/PAC" failure. Can add a UI hint on next load attempt. |
+| User switches back to URL input after selecting a file | The `content://` URI is replaced by the new HTTP URL text. Cache clears, new source takes effect. Normal flow. |
+| Large PAC files (e.g., corporate scripts > 1MB) | Read via `bufferedReader().readText()` — could be slow on large files. Existing 10s read timeout applies. |
+| Multiple PAC file selections in quick succession | Each selection triggers debounced save + cache clear (same as URL typing). No special handling needed. |
+| URI permissions across device reboots | `content://` URIs grant temporary permissions. If file is still accessible, system re-grants implicitly. If not, fetch fails gracefully as DIRECT. |
+
+---
+
+## Not In Scope (Future Enhancements)
+
+- **Edit PAC content inline**: A text editor composable showing/fetching PAC script content for review
+- **PAC content hash caching**: Cache by file content hash instead of URI string (handles re-selection of same file with different content)
+- **"Recent files" list**: Persist last N selected file URIs for quick re-selection
+- **MIME type enforcement**: Strict checking that selected file is actually a JS/PAC file before accepting
+- **Permission restoration UI**: Explicit prompt if file access is revoked (currently fails silently as DIRECT)

--- a/notes/PROXY-PAC-FROMFILE_v4.md
+++ b/notes/PROXY-PAC-FROMFILE_v4.md
@@ -1,0 +1,1393 @@
+---
+name: Load Proxy PAC from Local File (v4)
+description: Plan for adding local file support to proxy PAC configuration in SettingsScreen, BulkActions JSON configs, GoogleTimeSyncViewModel, and HttpsCertViewModel. Includes Settings file copy-to-private-storage, Context injection into all ViewModels, FileSystemIO abstraction, mutual exclusion validation, and parse-time skip flag.
+type: project
+---
+
+# Plan: Load Proxy PAC from Local File (v4)
+
+## Goal
+
+1. **SettingsScreen**: Allow users to load a PAC script from a local file via SAF picker. The selected file content is **copied** into the app's private storage on selection, then the internal path is stored and restored across sessions. Segmented toggle (URL/File) switches between sources.
+2. **BulkActions JSON**: Add `file-proxypac` field supporting absolute filesystem paths with tilde (`~`) expansion to app's private files directory. Validate at parse time that the file exists (skippable in unit tests via `skipFileValidation`). Throw an error if both `url-proxypac` and `file-proxypac` are present (mutually exclusive).
+3. **GoogleTimeSyncViewModel & HttpsCertViewModel**: Both must work with proxy PAC files as well as PAC URLs. Inject `Context` into their constructors so `ProxyResolver` has access to the filesystem.
+
+---
+
+## Design Decisions (v4)
+
+### 1. ProxyResolver — Option B: New Primary Constructor + Deprecated Companion Factory
+
+**Decision**: Add `Context? appContext = null` as the new last parameter to the **existing primary constructor**. The old call pattern (`ProxyResolver(repo, jsEngine, logger = ...)`) continues working with `appContext = null`. For a clean migration path, add a deprecated companion factory `withoutFileSupport()` that existing call sites can use instead.
+
+```kotlin
+class ProxyResolver(
+    private val settingsRepository: SettingsRepository,
+    private val jsEngine: JsEngine,
+    private val staticPacUrl: String? = null,
+    private val logger: ProxyPacLogger? = null,
+    private val forceLogging: Boolean = false,
+    private val appContext: Context? = null,     // NEW — for file-based PAC
+) {
+      // ... all existing code
+
+    companion object {
+          // ... existing forStaticPacUrl() stays unchanged (passes context → enables file + URL)
+
+          /**
+           * Creates a ProxyResolver without file-based PAC support.
+           * Use this to migrate existing call sites; eventually remove after migration.
+           */
+          @Deprecated(
+               message = "Use constructor with Context for file-based PAC, or forStaticPacUrl()",
+               replaceWith = ReplaceWith(
+                    "ProxyResolver(settingsRepository, jsEngine, staticPacUrl, logger, forceLogging, appContext)",
+                    "io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyResolver"
+                )
+          )
+          fun withoutFileSupport(
+              settingsRepository: SettingsRepository,
+              jsEngine: JsEngine,
+              staticPacUrl: String? = null,
+              logger: ProxyPacLogger? = null,
+              forceLogging: Boolean = false,
+           ): ProxyResolver = ProxyResolver(
+              settingsRepository = settingsRepository,
+              jsEngine = jsEngine,
+              staticPacUrl = staticPacUrl,
+              logger = logger,
+              forceLogging = forceLogging,
+              appContext = null,
+           )
+       }
+}
+```
+
+**Why**: The new primary constructor is the single source of truth. Existing call sites continue working without changes (defaulting to `appContext = null`). When ready to migrate, each site switches to `ProxyResolver.withoutFileSupport(repo, jsEngine, ...)` which delegates with `appContext = null`. New code that needs file access uses the primary constructor directly or `forStaticPacUrl()`.
+
+---
+
+### 2. SettingsScreen — Segmented Toggle + Single Field + Copy-to-Private-Storage
+
+**Decision**: A segmented chip/button group at the top of the Proxy Configuration section: `[ URL | File ]`, with the active selection highlighted. The PAC URL field below changes its placeholder and supporting text based on mode.
+
+```
+┌─────────────────────────────────────┐
+│ Enable Proxy     [Switch]                │
+│ Route traffic through a PAC proxy      │
+├─────────────────────────────────────┤
+│ [ URL ● | File ○ ]                     │
+├─────────────────────────────────────┤
+│ PAC URL                                │
+│ ┌──────────────────────────────────┐│
+│ │ http://proxy.corp.com/proxy.pac     ││
+│ └──────────────────────────────────┘│
+│ URL to an auto-configuration (.pac) script                       │
+└─────────────────────────────────────┘
+```
+
+When "File" is selected:
+```
+┌─────────────────────────────────────┐
+│ Enable Proxy     [Switch]                │
+│ Route traffic through a PAC proxy      │
+├─────────────────────────────────────┤
+│ [ URL ○ | File ● ]                     │
+├─────────────────────────────────────┤
+│ PAC File                               │
+│ ┌──────────────────────────────────┐│
+│ │ /data/user/0/app/files/saved-pac.pac││
+│ └──────────────────────────────────┘│
+│ Local file: saved-pac.pac              │
+└─────────────────────────────────────┘
+```
+
+**Copy-to-Private-Storage Decision**: When user selects a file via SAF picker, the file content is **copied** into the app's private files directory (e.g., `context.openFileOutput("saved-pac.pac", Context.MODE_PRIVATE)`) and the internal path (`context.filesDir.resolve("saved-pac.pac").absolutePath`) is stored. This guarantees persistence regardless of SAF provider (Google Drive, Downloads, cloud-backed storage).
+
+**Why**: SAF URIs like `content://com.android.externalstorage...` often return non-useable or non-persistent paths from `.path`. Files pushed via ADB to `/sdcard/Downloads/proxy.pac` work with direct path storage, but cloud-backed files may not survive reboots. Copying ensures reliability across all providers.
+
+---
+
+### 3. SettingsScreen — Toggle as State in ViewModel
+
+**Decision**: Add `pacSourceMode: PacSourceMode` to `SettingsUiState`, where `PacSourceMode` is an `enum class` with values `URL` and `FILE`. The UI reads this state to show/hide the Browse button and adjust labels/placeholders.
+
+---
+
+### 4. SettingsScreen — File Mode Copies to Private Storage
+
+**Decision**: When user selects a file via SAF picker:
+- Copy the file content into app's private files dir (`context.openFileOutput("saved-pac.pac", Context.MODE_PRIVATE)`)
+- Store the internal path (`context.filesDir.resolve("saved-pac.pac").absolutePath`) in `proxyPacUrl` field
+- On subsequent loads, restore from this internal path — always accessible via `openFileInput()` or `File(path)`
+
+**Why**: Absolute paths work across app sessions and reboots for files in private storage. SAF URIs expire. Copying to private storage is the most robust approach for all file sources (ADB-pushed, cloud-backed, Downloads).
+
+---
+
+### 5. BulkActions — `file-proxypac` as Absolute Path with ~ Expansion to App Files Dir
+
+**Decision**: `file-proxypac` stores a filesystem path string. Supports tilde (`~`) expansion to the app's private files directory (same mechanism as existing `expandTilde()` for `output-file`). Validate at parse time that the resolved file exists and is readable. Throw a validation error if not.
+
+**No tilde expansion in Settings file mode** — if a user types `~/proxy.pac` in the Settings file field, it stays literal (no expansion). Only BulkActions JSON configs get tilde expansion.
+
+**Skip File Validation Flag**: Add `@Volatile internal var skipFileValidation: Boolean = false` to `BulkConfigParser` (default `false`). When set to `true`, unit tests can skip file existence checks without needing to create temp files on disk.
+
+---
+
+### 6. BulkActions — Mutual Exclusion Validation
+
+**Decision**: If both `url-proxypac` and `file-proxypac` are present and non-blank in the same JSON config, `BulkConfigParser.parse()` throws an `IllegalArgumentException` with message: `"Cannot specify both 'url-proxypac' and 'file-proxypac'. They are mutually exclusive."`. This is caught by the ViewModel's loading flow and shown as a `ValidationMessage.Error`.
+
+---
+
+### 7. ProxyResolver — Unified Fetch Method with FileSystemIO Abstraction
+
+**Decision**:
+
+a) Add a `FileSystemIO` interface abstracting file operations:
+```kotlin
+/**
+ * Abstracts file system operations for PAC script loading.
+ *
+ * Enables unit testing by allowing a mock implementation that returns
+ * fake PAC content without touching the real filesystem.
+ */
+interface FileSystemIO {
+    fun canRead(path: String): Boolean
+    fun isFile(path: String): Boolean
+    fun exists(path: String): Boolean
+    fun readText(path: String): String
+}
+
+/** Default production implementation wrapping [java.io.File]. */
+internal object DefaultFileSystemIO : FileSystemIO {
+    override fun canRead(path: String) = java.io.File(path).canRead()
+    override fun isFile(path: String) = java.io.File(path).isFile
+    override fun exists(path: String) = java.io.File(path).exists()
+    override fun readText(path: String) = java.io.File(path).readText(Charsets.UTF_8)
+}
+```
+
+b) Add `fetchPacFromFile(filePath: String, fs: FileSystemIO): String?` that uses the abstraction. Production code passes `DefaultFileSystemIO`; tests inject a mock via `mockk()` that returns fake PAC script content without touching the real filesystem.
+
+**Visibility**: `fetchPacFromFile()` is `internal` (not `private`) with `@visibleForTesting` KDoc, so unit tests can invoke it directly via reflection or direct access within the same module.
+
+c) The existing `resolveProxy()` routing logic expands to three cases:
+- `http://` or `https://` → `fetchPacScript()` (HTTP GET)
+- Absolute file path (no scheme prefix) → `fetchPacFromFile()` (local read via FileSystemIO)
+- No Context available → log failure, return null
+
+The effective PAC source is determined by checking the first characters: if it starts with a scheme (`http://`, `https://`), use HTTP; otherwise treat as filesystem path.
+
+---
+
+### 8. GoogleTimeSyncViewModel & HttpsCertViewModel — Accept Context in Constructor
+
+**Decision**: Both ViewModels currently create `ProxyResolver` inline in their companion factory without passing `Context`. To support file-based PAC, they must accept `Context?` in their primary constructor and pass it through to `ProxyResolver`.
+
+```kotlin
+class GoogleTimeSyncViewModel(
+    private val repository    : GoogleTimeSyncRepository     = GoogleTimeSyncRepository(),
+    private val historyStore  : GoogleTimeSyncHistoryStore,
+    private val settingsRepository: SettingsRepository,
+    private val appContext    : Context? = null,       // NEW — for file-based PAC
+) : ViewModel() { ... }
+
+class HttpsCertViewModel(
+    private val repository    : HttpsCertRepository,
+    private val historyStore  : HttpsCertHistoryStore,
+    private val appContext    : Context? = null,         // NEW — for file-based PAC
+) : ViewModel() { ... }
+```
+
+**Factory updates**: Both factories pass `context.applicationContext` as the new param:
+
+```kotlin
+// GoogleTimeSyncViewModel.factory()
+fun factory(context: Context): ViewModelProvider.Factory =
+    object : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            val appContext = context.applicationContext
+            val settingsRepo = SettingsRepository(appContext)
+            val logger = ProxyPacLogger.getInstance(
+                logFile = java.io.File(appContext.filesDir, "proxypac-logs.txt"),
+             )
+            val proxyResolver = ProxyResolver(settingsRepo, QuickJsEngine(), logger = logger)
+            return GoogleTimeSyncViewModel(
+                repository    = GoogleTimeSyncRepository(proxyResolver),
+                historyStore  = GoogleTimeSyncHistoryStore(appContext),
+                settingsRepository = settingsRepo,
+                appContext    = appContext,       // NEW
+             ) as T
+         }
+     }
+
+// HttpsCertViewModel.factory()
+fun factory(context: Context): ViewModelProvider.Factory =
+    object : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            val appContext = context.applicationContext
+            val settingsRepo = SettingsRepository(appContext)
+            val logger = ProxyPacLogger.getInstance(
+                logFile = java.io.File(appContext.filesDir, "proxypac-logs.txt"),
+             )
+            val proxyResolver = ProxyResolver(settingsRepo, QuickJsEngine(), logger = logger)
+            return HttpsCertViewModel(
+                repository    = HttpsCertRepository(proxyResolver),
+                historyStore  = HttpsCertHistoryStore(appContext),
+                appContext    = appContext,       // NEW
+             ) as T
+         }
+     }
+```
+
+**Why**: Both ViewModels need `Context` so that `ProxyResolver` can access the filesystem when resolving proxy settings from a file path. The existing `factory(context)` already receives `Context`, so this is just threading it through to the constructor. No composable changes needed — `viewModel(factory = ...)` pattern is unchanged.
+
+---
+
+## Implementation Plan
+
+### Step 1: `proxy/ProxyResolver.kt` — New constructor param, FileSystemIO, file reading + routing
+
+**1a. Add `FileSystemIO` interface and default impl** (near top of file, before class):
+
+```kotlin
+/**
+ * Abstracts file system operations for PAC script loading.
+ *
+ * Enables unit testing by allowing a mock implementation that returns
+ * fake PAC content without touching the real filesystem.
+ */
+interface FileSystemIO {
+    fun canRead(path: String): Boolean
+    fun isFile(path: String): Boolean
+    fun exists(path: String): Boolean
+    fun readText(path: String): String
+}
+
+/** Default production implementation wrapping [java.io.File]. */
+internal object DefaultFileSystemIO : FileSystemIO {
+    override fun canRead(path: String) = java.io.File(path).canRead()
+    override fun isFile(path: String) = java.io.File(path).isFile
+    override fun exists(path: String) = java.io.File(path).exists()
+    override fun readText(path: String) = java.io.File(path).readText(Charsets.UTF_8)
+}
+```
+
+**1b. Add `Context?` as new last parameter to primary constructor + deprecated companion factory**:
+
+Replace the existing class signature (add `appContext: Context? = null` as last parameter):
+
+```kotlin
+class ProxyResolver(
+    private val settingsRepository: SettingsRepository,
+    private val jsEngine: JsEngine,
+    private val staticPacUrl: String? = null,
+    private val logger: ProxyPacLogger? = null,
+    private val forceLogging: Boolean = false,
+    private val appContext: Context? = null,     // NEW — for file-based PAC
+) {
+      // ... all existing code
+
+    companion object {
+          // ... existing forStaticPacUrl() stays unchanged (passes context → enables file + URL)
+
+          /**
+           * Creates a ProxyResolver without file-based PAC support.
+           * Use this to migrate existing call sites; eventually remove after migration.
+           */
+          @Deprecated(
+               message = "Use constructor with Context for file-based PAC, or forStaticPacUrl()",
+               replaceWith = ReplaceWith(
+                    "ProxyResolver(settingsRepository, jsEngine, staticPacUrl, logger, forceLogging, appContext)",
+                    "io.github.mobilutils.ntp_dig_ping_more.proxy.ProxyResolver"
+                )
+          )
+          fun withoutFileSupport(
+              settingsRepository: SettingsRepository,
+              jsEngine: JsEngine,
+              staticPacUrl: String? = null,
+              logger: ProxyPacLogger? = null,
+              forceLogging: Boolean = false,
+           ): ProxyResolver = ProxyResolver(
+              settingsRepository = settingsRepository,
+              jsEngine = jsEngine,
+              staticPacUrl = staticPacUrl,
+              logger = logger,
+              forceLogging = forceLogging,
+              appContext = null,
+           )
+       }
+}
+```
+
+**Then update existing call sites to use `withoutFileSupport()`**:
+
+| File | Current Call | New Call |
+|---|---|---|
+| `SettingsViewModel.kt:331` | `ProxyResolver(settingsRepository, jsEngine, logger = logger)` | **MIGRATE** — pass `appContext = context.applicationContext` (needed for Settings file mode) |
+| `GoogleTimeSyncViewModel.kt:187` | `ProxyResolver(settingsRepo, QuickJsEngine(), logger = logger)` | **MIGRATE** — accept `Context?` in constructor, pass to ProxyResolver primary ctor |
+| `HttpsCertViewModel.kt:222` | `ProxyResolver(settingsRepo, QuickJsEngine(), logger = logger)` | **MIGRATE** — accept `Context?` in constructor, pass to ProxyResolver primary ctor |
+| `ProxyResolverTest.kt:38` | `ProxyResolver(settingsRepository, jsEngine)` | `ProxyResolver.withoutFileSupport(settingsRepository, jsEngine)` |
+
+SettingsScreen is the one that needs migration because it's the only screen where users actively select PAC files. GoogleTimeSync and HttpsCert are also migrated (Step 8) to support file-based proxy for their commands.
+
+**1c. Add `fetchPacFromFile()` method** (`internal` with `@visibleForTesting`):
+
+```kotlin
+/**
+ * Fetches a PAC script from an absolute filesystem path.
+ * Uses the same caching contract as fetchPacScript().
+ *
+ * @param filePath Absolute path to the .pac file.
+ * @param fs       FileSystemIO abstraction (default: [DefaultFileSystemIO]).
+ * @return The PAC script content, or `null` if the file is inaccessible.
+ */
+@VisibleForTesting
+internal fun fetchPacFromFile(
+    filePath: String,
+    fs: FileSystemIO = DefaultFileSystemIO,
+): String? {
+    if (!fs.exists(filePath) || !fs.isFile(filePath) || !fs.canRead(filePath)) {
+        logIfEnabled("PAC_FETCH_FAIL path=$filePath reason=file not accessible")
+        return null
+     }
+
+    val now = System.currentTimeMillis()
+    if (cachedPacScript != null && cachedPacUrl == filePath &&
+        now - pacFetchedAt < PAC_CACHE_TTL_MS
+     ) {
+        return cachedPacScript
+     }
+
+    return try {
+        val script = fs.readText(filePath)
+
+        cachedPacScript = script
+        cachedPacUrl = filePath
+        pacFetchedAt = now
+        logIfEnabled("PAC_FETCH_SUCCESS path=$filePath")
+        script
+     } catch (e: Exception) {
+        logIfEnabled("PAC_FETCH_FAIL path=$filePath reason=${e.message}")
+        null
+     }
+}
+```
+
+**1d. Update `resolveProxy()` routing** — replace the single fetch call with scheme-based dispatch:
+
+Replace this block in `resolveProxy()`:
+```kotlin
+// Fetch (or use cached) PAC script
+val pacScript = fetchPacScript(effectivePacUrl) ?: return@withContext null
+```
+
+With:
+```kotlin
+// Fetch (or use cached) PAC script — dispatch by source type
+val pacScript = when {
+    effectivePacUrl.startsWith("http://") || effectivePacUrl.startsWith("https://") ->
+        fetchPacScript(effectivePacUrl)
+    else ->
+         // Treat as filesystem path — requires Context for file access
+        if (appContext != null) {
+            fetchPacFromFile(effectivePacUrl)
+         } else {
+            logIfEnabled("PAC_FETCH_FAIL reason=no Context for file access")
+            null
+         }
+} ?: return@withContext null
+```
+
+**1e. No changes needed to `forStaticPacUrl()` factory** — it already passes `context` as the new `appContext` param, which enables both URL and file-based PAC.
+
+---
+
+### Step 2: Create `PacSourceMode.kt` — enum class
+
+**New file**: `app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/PacSourceMode.kt`
+
+```kotlin
+package io.github.mobilutils.ntp_dig_ping_more
+
+/** Enum of supported PAC script sources. */
+enum class PacSourceMode {
+     /** HTTP/HTTPS URL (existing behavior). */
+    URL,
+
+     /** Local filesystem path (private storage or absolute path). */
+    FILE;
+
+    companion object {
+         /** Default source mode for new Settings screens. */
+        val Default = URL
+     }
+}
+```
+
+---
+
+### Step 3: `SettingsViewModel.kt` — Add source mode tracking + file selection + copy-to-storage
+
+**3a. Add imports**:
+```kotlin
+import android.net.Uri
+import java.io.File
+```
+
+**3b. Accept `Context?` in constructor** (migrate from `withoutFileSupport()` pattern):
+
+Replace:
+```kotlin
+class SettingsViewModel(
+    private val settingsRepository: SettingsRepository,
+) : ViewModel() { ... }
+```
+
+With:
+```kotlin
+class SettingsViewModel(
+    private val settingsRepository: SettingsRepository,
+    private val appContext: Context? = null,   // NEW — for file-based PAC (copy-to-storage)
+) : ViewModel() { ... }
+```
+
+**Factory update**: Pass `context.applicationContext` to enable file mode:
+```kotlin
+companion object {
+    fun factory(context: Context): ViewModelProvider.Factory =
+        object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                val appContext = context.applicationContext
+                val settingsRepo = SettingsRepository(appContext)
+                val logger = ProxyPacLogger.getInstance(
+                    logFile = java.io.File(appContext.filesDir, "proxypac-logs.txt"),
+                 )
+                val proxyResolver = ProxyResolver(settingsRepo, QuickJsEngine(), logger = logger)
+                return SettingsViewModel(
+                    settingsRepository = settingsRepo,
+                    proxyResolver      = proxyResolver,
+                    appContext         = appContext,        // NEW
+                 ) as T
+             }
+         }
+}
+```
+
+**3c. Add `pacSourceMode` to `SettingsUiState`**:
+
+Replace:
+```kotlin
+data class SettingsUiState(
+    val timeoutInput: String = SettingsKeys.DEFAULT_TIMEOUT_SECONDS.toString(),
+    val isError: Boolean = false,
+    val savedTimeout: Int = SettingsKeys.DEFAULT_TIMEOUT_SECONDS,
+       // Proxy / PAC fields
+    val proxyEnabled: Boolean = false,
+    val proxyPacUrl: String = "",
+    val proxyPacUrlError: String? = null,
+```
+
+With:
+```kotlin
+data class SettingsUiState(
+    val timeoutInput: String = SettingsKeys.DEFAULT_TIMEOUT_SECONDS.toString(),
+    val isError: Boolean = false,
+    val savedTimeout: Int = SettingsKeys.DEFAULT_TIMEOUT_SECONDS,
+       // Proxy / PAC fields
+    val proxyEnabled: Boolean = false,
+    val pacSourceMode: PacSourceMode = PacSourceMode.Default,     // NEW
+    val proxyPacUrl: String = "",
+    val proxyPacUrlError: String? = null,
+```
+
+**3d. Add `onPacSourceModeChange(mode: PacSourceMode)` action**:
+
+```kotlin
+/**
+ * Toggles between URL and File source modes for PAC configuration.
+ * Clears the PAC URL when switching modes to avoid confusion.
+ */
+fun onPacSourceModeChange(mode: PacSourceMode) {
+     _uiState.value = _uiState.value.copy(
+        pacSourceMode = mode,
+        proxyPacUrl = "",     // Clear on switch to avoid stale content
+        proxyPacUrlError = null,
+     )
+    proxyResolver.clearCache()
+    viewModelScope.launch {
+        saveCurrentProxyConfig()
+     }
+}
+```
+
+**3e. Add `onPacFileSelected(uri: Uri)` action — copies to private storage**:
+
+```kotlin
+/**
+ * Called when the user selects a local PAC file via SAF picker.
+ * Copies the file content into app private storage, then stores the internal path.
+ */
+fun onPacFileSelected(uri: Uri) {
+    val internalPath = appContext?.let { ctx ->
+        runCatching {
+            // Copy selected file to private storage
+            val outputFile = File(ctx.filesDir, "saved-pac.pac")
+            ctx.contentResolver.openInputStream(uri)?.use { input ->
+                outputFile.outputStream().use { output ->
+                    input.copyTo(output)
+                 }
+               }
+            outputFile.absolutePath
+          }.getOrNull()
+      }
+
+    _uiState.value = _uiState.value.copy(
+        proxyPacUrl = internalPath ?: "",     // Store internal path, or empty on failure
+        proxyPacUrlError = if (internalPath == null) "Failed to copy file" else null,
+     )
+
+    if (internalPath != null) {
+        proxyResolver.clearCache()
+        viewModelScope.launch {
+            saveCurrentProxyConfig()
+         }
+      }
+}
+```
+
+**3f. Update `validatePacUrl()` — validate based on source mode**:
+
+Replace the entire function with:
+```kotlin
+internal fun validatePacUrl(url: String, mode: PacSourceMode = _uiState.value.pacSourceMode): String? {
+    if (url.isBlank()) return null
+
+    when (mode) {
+        PacSourceMode.URL -> {
+              // Existing HTTP/HTTPS URL validation...
+            return try {
+                val parsed = java.net.URL(url)
+                when {
+                    parsed.protocol !in listOf("http", "https") ->
+                          "Only http:// and https:// URLs are supported"
+                    parsed.host.isNullOrBlank() ->
+                          "URL must contain a hostname"
+                    else -> null
+                  }
+              } catch (_: Exception) {
+                  "Invalid URL format"
+              }
+          }
+        PacSourceMode.FILE -> {
+              // For file mode: internal paths from copy-to-storage are always valid.
+              // If user types a path manually, do basic validation (no tilde expansion).
+              // NOTE: No tilde expansion in Settings file mode — paths are literal.
+            return try {
+                val resolvedPath = if (url.startsWith("content://")) {
+                    android.net.Uri.parse(url).path ?: url
+                  } else {
+                    url
+                  }
+
+                  // Basic validation: must be a non-empty path
+                if (resolvedPath.isBlank() || resolvedPath == "/") {
+                      "Invalid file path"
+                  } else {
+                    null     // File existence checked at fetch time, not here
+                  }
+              } catch (_: Exception) {
+                  "Invalid file path"
+              }
+          }
+      }
+}
+```
+
+**3g. Update `onProxyPacUrlChange()` call to `validatePacUrl()` — pass current mode**:
+
+In the debounce block, change:
+```kotlin
+val error = validatePacUrl(url)
+```
+To:
+```kotlin
+val error = validatePacUrl(url, _uiState.value.pacSourceMode)
+```
+
+---
+
+### Step 4: `SettingsScreen.kt` — Add segmented toggle + SAF file picker + copy-to-storage
+
+**4a. Add imports**:
+```kotlin
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import android.net.Uri
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import java.io.File
+```
+
+**4b. Add SAF launcher in the `SettingsScreen()` composable** (right after `viewModel` and `uiState` declarations):
+
+```kotlin
+val pacFilePickerLauncher = rememberLauncherForActivityResult(
+    contract = ActivityResultContracts.GetContent()
+) { uri: Uri? ->
+    uri?.let { selectedUri ->
+        viewModel.onPacFileSelected(selectedUri)
+      }
+}
+```
+
+**4c. Add segmented toggle UI** (after the proxy enable toggle, before the PAC URL field):
+
+```kotlin
+// PAC source mode toggle
+Row(
+    modifier = Modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+) {
+    FilterChip(
+        selected = uiState.pacSourceMode == PacSourceMode.URL,
+        onClick = { viewModel.onPacSourceModeChange(PacSourceMode.URL) },
+        label = { Text("URL") },
+        colors = FilterChipDefaults.filterChipColors(
+            selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+            selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+          ),
+      )
+
+    FilterChip(
+        selected = uiState.pacSourceMode == PacSourceMode.FILE,
+        onClick = { viewModel.onPacSourceModeChange(PacSourceMode.FILE) },
+        label = { Text("File") },
+        colors = FilterChipDefaults.filterChipColors(
+            selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+            selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+          ),
+      )
+}
+```
+
+**4d. Replace the existing PAC URL `OutlinedTextField` block** with mode-aware controls:
+
+Replace:
+```kotlin
+OutlinedTextField(
+    value = uiState.proxyPacUrl,
+    onValueChange = viewModel::onProxyPacUrlChange,
+    modifier = Modifier.fillMaxWidth(),
+    label = { Text("PAC URL") },
+    placeholder = { Text("http://proxy.corp.com/proxy.pac") },
+    singleLine = true,
+    enabled = uiState.proxyEnabled,
+    isError = uiState.proxyPacUrlError != null,
+    supportingText = { /* ... */ },
+    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+)
+```
+
+With:
+```kotlin
+OutlinedTextField(
+    value = uiState.proxyPacUrl,
+    onValueChange = viewModel::onProxyPacUrlChange,
+    modifier = Modifier.fillMaxWidth(),
+    label = {
+        Text(
+            when (uiState.pacSourceMode) {
+                PacSourceMode.URL -> "PAC URL"
+                PacSourceMode.FILE -> "PAC File"
+              }
+          )
+      },
+    placeholder = {
+        Text(
+            when (uiState.pacSourceMode) {
+                PacSourceMode.URL -> "http://proxy.corp.com/proxy.pac"
+                PacSourceMode.FILE -> "/data/user/0/app/files/saved-pac.pac"
+              }
+          )
+      },
+    singleLine = true,
+    enabled = uiState.proxyEnabled,
+    isError = uiState.proxyPacUrlError != null,
+    supportingText = {
+        when {
+            uiState.proxyPacUrlError != null -> Text(
+                text = uiState.proxyPacUrlError!!,
+                color = MaterialTheme.colorScheme.error,
+             )
+            uiState.proxyEnabled && uiState.pacSourceMode == PacSourceMode.FILE &&
+                 uiState.proxyPacUrl.isNotBlank() && !uiState.proxyPacUrl.startsWith("content://") -> {
+                val fileName = File(uiState.proxyPacUrl).name
+                Text(
+                    text = "Local file: $fileName",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                 )
+              }
+            uiState.proxyEnabled && uiState.pacSourceMode == PacSourceMode.FILE -> Text(
+                text = "Browse to select a local .pac file",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+             )
+            uiState.proxyEnabled -> Text(
+                text = "URL to an auto-configuration (.pac) script",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+             )
+          }
+      },
+    keyboardOptions = when (uiState.pacSourceMode) {
+        PacSourceMode.URL -> KeyboardOptions(keyboardType = KeyboardType.Uri)
+        PacSourceMode.FILE -> KeyboardOptions(keyboardType = KeyboardType.Text)
+      },
+    trailingIcon = when (uiState.pacSourceMode) {
+        PacSourceMode.URL -> null     // No trailing icon for URL mode
+        PacSourceMode.FILE -> {
+            if (uiState.proxyEnabled) {
+                  {
+                    TextButton(
+                        onClick = { pacFilePickerLauncher.launch("application/javascript") },
+                      ) {
+                        Text("Browse")
+                      }
+                  }
+              } else null
+          }
+      },
+)
+```
+
+---
+
+### Step 5: `BulkConfigParser.kt` / `BulkActionsRepository.kt` — Add `file-proxypac` field + validation + ~ expansion + skip flag
+
+**5a. Update `BulkConfig` data class**:
+
+Replace:
+```kotlin
+data class BulkConfig(
+    val outputFile: String?,
+    val commands: Map<String, String>,
+    val timeoutMs: Long? = null,
+    val outputAsCsv: Boolean = false,
+    val urlProxyPac: String? = null,
+    val logProxy: Boolean? = null,
+)
+```
+
+With:
+```kotlin
+data class BulkConfig(
+    val outputFile: String?,
+    val commands: Map<String, String>,
+    val timeoutMs: Long? = null,
+    val outputAsCsv: Boolean = false,
+    val urlProxyPac: String? = null,
+    val fileProxyPac: String? = null,     // NEW — absolute filesystem path with ~ expansion to app files dir
+    val logProxy: Boolean? = null,
+)
+```
+
+**5b. Add `skipFileValidation` flag to BulkConfigParser**:
+
+After the existing `appContext` property in `BulkConfigParser` object:
+```kotlin
+object BulkConfigParser {
+
+     /** Application context, set once by BulkActionsViewModel factory. Used for private-dir path expansion. */
+     @Volatile
+    internal var appContext: Context? = null
+
+     /** When true, skip file existence checks during parse (for unit tests). Default: false. */
+     @Volatile
+    internal var skipFileValidation: Boolean = false
+
+     // ... rest of object
+}
+```
+
+**5c. Update `BulkConfigParser.parse()`** — add `file-proxypac` parsing + mutual exclusion validation:
+
+After the existing `urlProxyPac` and before `logProxy` parsing blocks (around line 118), add:
+
+```kotlin
+val fileProxyPac = runCatching {
+    val path = root.optString("file-proxypac", "")
+    if (path.isNullOrBlank()) null else expandTilde(path.trim())
+}.getOrNull()
+
+// Mutual exclusion validation — throw if both are present
+if (!urlProxyPac.isNullOrBlank() && !fileProxyPac.isNullOrBlank()) {
+    throw IllegalArgumentException(
+          "Cannot specify both 'url-proxypac' and 'file-proxypac'. They are mutually exclusive."
+      )
+}
+```
+
+**5d. Add `file-proxypac` existence validation at parse time**:
+
+After parsing `fileProxyPac`, add:
+
+```kotlin
+// Validate file-proxypac exists and is readable (parse-time validation, skippable in tests)
+if (!fileProxyPac.isNullOrBlank() && !skipFileValidation) {
+    val file = java.io.File(fileProxyPac)
+    if (!file.exists() || !file.isFile || !file.canRead()) {
+        throw IllegalArgumentException(
+              "file-proxypac points to inaccessible file: $fileProxyPac. " +
+                  "Ensure the file exists and is readable."
+          )
+      }
+}
+```
+
+**5e. Existing `expandTilde()` in BulkConfigParser** — already expands to app's private files dir (verified from code reading). No changes needed.
+
+---
+
+### Step 6: `BulkActionsViewModel.kt` — Wire `file-proxypac` into proxy resolver setup
+
+**6a. Update proxy resolver setup calls** — pass either URL or file path:
+
+In `onLoadAndRun()` (around line 252) and `onRunClicked()` (around line 337), replace:
+```kotlin
+repository.setupProxyResolver(config.urlProxyPac, forceLogging = config.logProxy == true)
+```
+
+With:
+```kotlin
+val pacSource = config.fileProxyPac ?: config.urlProxyPac
+repository.setupProxyResolver(pacSource, forceLogging = config.logProxy == true)
+```
+
+**No changes needed to `setupProxyResolver()` or `clearProxyResolver()` in BulkActionsRepository** — they already accept a nullable `String?` and pass it through to `ProxyResolver.forStaticPacUrl()`. The routing logic in `resolveProxy()` (Step 1d) will dispatch based on scheme.
+
+---
+
+### Step 7: `GoogleTimeSyncViewModel.kt` — Accept Context, enable file-based PAC
+
+**7a. Add `Context?` to constructor**:
+
+Replace:
+```kotlin
+class GoogleTimeSyncViewModel(
+    private val repository    : GoogleTimeSyncRepository     = GoogleTimeSyncRepository(),
+    private val historyStore  : GoogleTimeSyncHistoryStore,
+    private val settingsRepository: SettingsRepository,
+) : ViewModel() { ... }
+```
+
+With:
+```kotlin
+class GoogleTimeSyncViewModel(
+    private val repository    : GoogleTimeSyncRepository     = GoogleTimeSyncRepository(),
+    private val historyStore  : GoogleTimeSyncHistoryStore,
+    private val settingsRepository: SettingsRepository,
+    private val appContext    : Context? = null,       // NEW — for file-based PAC
+) : ViewModel() { ... }
+```
+
+**7b. Update factory to pass Context**:
+
+Replace:
+```kotlin
+val proxyResolver = ProxyResolver(settingsRepo, QuickJsEngine(), logger = logger)
+return GoogleTimeSyncViewModel(
+    repository    = GoogleTimeSyncRepository(proxyResolver),
+    historyStore  = GoogleTimeSyncHistoryStore(appContext),
+    settingsRepository = settingsRepo,
+) as T
+```
+
+With:
+```kotlin
+val proxyResolver = ProxyResolver(settingsRepo, QuickJsEngine(), logger = logger)
+return GoogleTimeSyncViewModel(
+    repository    = GoogleTimeSyncRepository(proxyResolver),
+    historyStore  = GoogleTimeSyncHistoryStore(appContext),
+    settingsRepository = settingsRepo,
+    appContext    = appContext,       // NEW — enables file-based PAC for google-timesync command
+) as T
+```
+
+**No changes needed to `syncTime()` method** — it uses `GoogleTimeSyncRepository` which internally uses the injected `ProxyResolver`. The `ProxyResolver` now has `appContext` and will dispatch file vs URL routes automatically.
+
+---
+
+### Step 8: `HttpsCertViewModel.kt` — Accept Context, enable file-based PAC
+
+**8a. Add `Context?` to constructor**:
+
+Replace:
+```kotlin
+class HttpsCertViewModel(
+    private val repository: HttpsCertRepository,
+    private val historyStore: HttpsCertHistoryStore,
+) : ViewModel() { ... }
+```
+
+With:
+```kotlin
+class HttpsCertViewModel(
+    private val repository: HttpsCertRepository,
+    private val historyStore: HttpsCertHistoryStore,
+    private val appContext: Context? = null,         // NEW — for file-based PAC
+) : ViewModel() { ... }
+```
+
+**8b. Update factory to pass Context**:
+
+Replace:
+```kotlin
+val proxyResolver = ProxyResolver(settingsRepo, QuickJsEngine(), logger = logger)
+return HttpsCertViewModel(
+    repository    = HttpsCertRepository(proxyResolver),
+    historyStore  = HttpsCertHistoryStore(appContext),
+) as T
+```
+
+With:
+```kotlin
+val proxyResolver = ProxyResolver(settingsRepo, QuickJsEngine(), logger = logger)
+return HttpsCertViewModel(
+    repository    = HttpsCertRepository(proxyResolver),
+    historyStore  = HttpsCertHistoryStore(appContext),
+    appContext    = appContext,       // NEW — enables file-based PAC for checkcert command
+) as T
+```
+
+**No changes needed to `fetchCert()` method** — it uses `HttpsCertRepository` which internally uses the injected `ProxyResolver`. The `ProxyResolver` now has `appContext` and will dispatch file vs URL routes automatically.
+
+---
+
+### Step 9: Tests
+
+#### 9a. `SettingsViewModelTest.kt` — Add tests
+
+```kotlin
+// ── PAC source mode ──────────────────────────────────────────────────────
+
+@Test
+fun `initial state has URL as default source mode`() = runTest {
+    testDispatcher.scheduler.advanceUntilIdle()
+    assertEquals(PacSourceMode.URL, viewModel.uiState.value.pacSourceMode)
+}
+
+@Test
+fun `onPacSourceModeChange switches to FILE and clears URL`() = runTest {
+      // Set a URL first
+    viewModel.onProxyPacUrlChange("http://proxy.corp.com/proxy.pac")
+    testDispatcher.scheduler.advanceUntilIdle()
+
+      // Switch to FILE mode
+    viewModel.onPacSourceModeChange(PacSourceMode.FILE)
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    assertEquals(PacSourceMode.FILE, viewModel.uiState.value.pacSourceMode)
+    assertEquals("", viewModel.uiState.value.proxyPacUrl)
+    assertNull(viewModel.uiState.value.proxyPacUrlError)
+    io.mockk.verify { proxyResolver.clearCache() }
+    coVerify { settingsRepository.saveProxyConfig(any()) }
+}
+
+@Test
+fun `onPacSourceModeChange switches to URL and clears file path`() = runTest {
+      // Set a file path
+    viewModel.onPacSourceModeChange(PacSourceMode.FILE)
+    testDispatcher.scheduler.advanceUntilIdle()
+    viewModel.onProxyPacUrlChange("/data/user/0/app/files/saved-pac.pac")
+    testDispatcher.scheduler.advanceUntilIdle()
+
+      // Switch back to URL mode
+    viewModel.onPacSourceModeChange(PacSourceMode.URL)
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    assertEquals(PacSourceMode.URL, viewModel.uiState.value.pacSourceMode)
+    assertEquals("", viewModel.uiState.value.proxyPacUrl)
+}
+
+// ── PAC file selection (copy-to-storage) ─────────────────────────────────
+
+@Test
+fun `onPacFileSelected copies content to private storage and stores path`() = runTest {
+      // Mock: simulate SAF URI → copy to private storage succeeds
+    val fakeUri = Uri.parse("content://com.android.externalstorage.documents/document/324-162:proxy.pac")
+
+      // Verify appContext is not null in this test (SettingsViewModel needs Context for file mode)
+    assertNotNull(viewModel.appContext)
+
+    viewModel.onPacFileSelected(fakeUri)
+    testDispatcher.scheduler.advanceUntilIdle()
+
+      // The stored path should be the internal private storage path
+    val storedPath = viewModel.uiState.value.proxyPacUrl
+    assertTrue(storedPath.startsWith("/data/user/0/io.github.mobilutils.ntp_dig_ping_more/files/"))
+    assertTrue(storedPath.endsWith("saved-pac.pac"))
+
+      // Verify URL is cleared, no error
+    assertNull(viewModel.uiState.value.proxyPacUrlError)
+    coVerify { settingsRepository.saveProxyConfig(any()) }
+}
+
+@Test
+fun `onPacFileSelected stores error when copy fails`() = runTest {
+      // When appContext is null (not set up for file mode), onPacFileSelected should fail gracefully
+    val vmWithoutContext = SettingsViewModel(settingsRepository, proxyResolver, appContext = null)
+    val fakeUri = Uri.parse("content://com.../proxy.pac")
+
+    vmWithoutContext.onPacFileSelected(fakeUri)
+    testDispatcher.scheduler.advanceUntilIdle()
+
+      // Should store empty string and show error
+    assertEquals("", vmWithoutContext.uiState.value.proxyPacUrl)
+    assertNotNull(vmWithoutContext.uiState.value.proxyPacUrlError)
+    assertTrue(vmWithoutContext.uiState.value.proxyPacUrlError!!.contains("Failed to copy"))
+}
+
+@Test
+fun `onPacFileSelected clears error and persists config`() = runTest {
+      // Set an invalid URL first, then select a file to clear it
+    viewModel.onProxyPacUrlChange("not a url")
+    testDispatcher.scheduler.advanceTimeBy(400)
+    testDispatcher.scheduler.advanceUntilIdle()
+    assertTrue(viewModel.uiState.value.proxyPacUrlError != null)
+
+      // Select a file (simulates successful copy)
+    val fakeUri = Uri.parse("content://com.../proxy.pac")
+    viewModel.onPacFileSelected(fakeUri)
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    assertNull(viewModel.uiState.value.proxyPacUrlError)
+    coVerify { settingsRepository.saveProxyConfig(any()) }
+}
+
+@Test
+fun `onPacFileSelected clears proxy cache`() = runTest {
+    val fakeUri = Uri.parse("content://com.../proxy.pac")
+    viewModel.onPacFileSelected(fakeUri)
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    io.mockk.verify { proxyResolver.clearCache() }
+}
+
+// ── Validation: FILE mode ────────────────────────────────────────────────
+
+@Test
+fun `validatePacUrl accepts internal private storage path in FILE mode`() {
+    val vm = SettingsViewModel(settingsRepository, proxyResolver, appContext = mockk())
+      // Internal paths from copy-to-storage are always valid (no existence check at validate time)
+    assertNull(vm.validatePacUrl("/data/user/0/app/files/saved-pac.pac", PacSourceMode.FILE))
+}
+
+@Test
+fun `validatePacUrl accepts content:// URI in FILE mode`() {
+    val vm = SettingsViewModel(settingsRepository, proxyResolver, appContext = mockk())
+    val uri = "content://com.android.externalstorage.documents/document/123-proxy.pac"
+    assertNull(vm.validatePacUrl(uri, PacSourceMode.FILE))
+}
+
+@Test
+fun `validatePacUrl rejects empty path in FILE mode`() {
+    val vm = SettingsViewModel(settingsRepository, proxyResolver, appContext = mockk())
+    val error = vm.validatePacUrl("/", PacSourceMode.FILE)
+    assertTrue(error != null && error.contains("Invalid"))
+}
+
+@Test
+fun `validatePacUrl rejects malformed content:// URI in FILE mode`() {
+    val vm = SettingsViewModel(settingsRepository, proxyResolver, appContext = mockk())
+    val badUri = "content://"
+    val error = vm.validatePacUrl(badUri, PacSourceMode.FILE)
+    assertTrue(error != null)
+}
+
+// ── Validation: URL mode (unchanged) ─────────────────────────────────────
+
+@Test
+fun `validatePacUrl in URL mode accepts valid HTTP URL`() {
+    assertNull(viewModel.validatePacUrl("http://proxy.corp.com/proxy.pac", PacSourceMode.URL))
+}
+
+@Test
+fun `validatePacUrl in URL mode rejects FTP URL`() {
+    val error = viewModel.validatePacUrl("ftp://proxy.corp.com/proxy.pac", PacSourceMode.URL)
+    assertTrue(error != null && error.contains("http"))
+}
+```
+
+#### 9b. `BulkConfigParserTest.kt` — Add tests
+
+```kotlin
+// ── file-proxypac parsing ────────────────────────────────────────────────
+
+@Test
+fun `parseConfigWithFileProxyPac_returnsPath_whenSkipValidation`() {
+      // Enable skip flag to avoid needing real file on disk
+    BulkConfigParser.skipFileValidation = true
+    try {
+        val json = """{
+               "run": { "ping_test": "ping -c 3 google.com" },
+               "file-proxypac": "/sdcard/Downloads/proxy.pac"
+           }"""
+
+        val config = BulkConfigParser.parse(json)
+        assertEquals("/sdcard/Downloads/proxy.pac", config.fileProxyPac)
+    } finally {
+        BulkConfigParser.skipFileValidation = false
+     }
+}
+
+@Test
+fun `parseConfigWithBothUrlAndFileProxyPac_throwsError`() {
+    val json = """{
+           "run": { "ping_test": "ping -c 3 google.com" },
+           "url-proxypac": "http://proxy.corp.com/proxy.pac",
+           "file-proxypac": "/sdcard/Downloads/proxy.pac"
+       }"""
+
+    assertThrows<IllegalArgumentException> {
+        BulkConfigParser.parse(json)
+      }
+}
+
+@Test
+fun `parseConfigWithBlankFileProxyPac_returnsNull`() {
+    val json = """{
+           "run": { "ping_test": "ping -c 3 google.com" },
+           "file-proxypac": ""
+       }"""
+
+    val config = BulkConfigParser.parse(json)
+    assertNull(config.fileProxyPac)
+}
+
+@Test
+fun `parseConfigWithMissingFileProxyPac_returnsNull`() {
+    val json = """{
+           "run": { "ping_test": "ping -c 3 google.com" }
+       }"""
+
+    val config = BulkConfigParser.parse(json)
+    assertNull(config.fileProxyPac)
+}
+
+@Test
+fun `parseConfigWithUrlProxyPacAndFileProxyPacPreservesOtherFields_throws`() {
+      // Test that mutual exclusion error is thrown, not silent failure
+    val json = """{
+           "output-file": "/tmp/test.txt",
+           "url-proxypac": "http://proxy.corp.com/proxy.pac",
+           "file-proxypac": "/sdcard/Downloads/proxy.pac",
+           "log-proxy": true,
+           "run": { "ping_test": "ping -c 3 google.com" }
+       }"""
+
+    assertThrows<IllegalArgumentException> {
+        BulkConfigParser.parse(json)
+      }
+}
+
+@Test
+fun `parseConfigWithFileProxyPac_andTilde_expands_whenSkipValidation`() {
+    BulkConfigParser.skipFileValidation = true
+    try {
+          // Set appContext for tilde expansion
+        val mockCtx = mockk<Context>(relaxed = true)
+        every { mockCtx.applicationContext.filesDir.absolutePath } returns "/data/user/0/app/files"
+        BulkConfigParser.appContext = mockCtx
+
+        val json = """{
+               "run": { "ping_test": "ping -c 3 google.com" },
+               "file-proxypac": "~/proxy.pac"
+           }"""
+
+        val config = BulkConfigParser.parse(json)
+        assertEquals("/data/user/0/app/files/proxy.pac", config.fileProxyPac)
+    } finally {
+        BulkConfigParser.skipFileValidation = false
+        BulkConfigParser.appContext = null
+     }
+}
+
+@Test
+fun `parseConfigWithInaccessibleFileProxyPac_throws_whenValidationEnabled`() {
+      // skipFileValidation is false by default — this should throw
+    val json = """{
+           "run": { "ping_test": "ping -c 3 google.com" },
+           "file-proxypac": "/nonexistent/path/proxy.pac"
+       }"""
+
+    assertThrows<IllegalArgumentException> {
+        BulkConfigParser.parse(json)
+      }
+}
+```
+
+#### 9c. `ProxyResolverTest.kt` — Add tests for file-based PAC (unit tests with FileSystemIO mock)
+
+```kotlin
+// ── fetchPacFromFile tests (unit tests with mocked FileSystemIO) ───────────
+
+@Test
+fun `fetchPacFromFile reads PAC script from valid path via mock FS`() {
+    val mockFs = mockk<FileSystemIO>()
+    every { mockFs.exists("/tmp/test.pac") } returns true
+    every { mockFs.isFile("/tmp/test.pac") } returns true
+    every { mockFs.canRead("/tmp/test.pac") } returns true
+    every { mockFs.readText("/tmp/test.pac") } returns "function FindProxyForURL(u, h) { return 'DIRECT'; }"
+
+    val resolver = ProxyResolver.withoutFileSupport(settingsRepository, jsEngine)
+      // fetchPacFromFile is internal — accessible from same module in test scope
+    val result = resolver.fetchPacFromFile("/tmp/test.pac", mockFs)
+
+    assertNotNull(result)
+    assertEquals("function FindProxyForURL(u, h) { return 'DIRECT'; }", result)
+}
+
+@Test
+fun `fetchPacFromFile returns null for non-existent path`() {
+    val mockFs = mockk<FileSystemIO>()
+    every { mockFs.exists("/nonexistent/pac.pac") } returns false
+
+    val resolver = ProxyResolver.withoutFileSupport(settingsRepository, jsEngine)
+    val result = resolver.fetchPacFromFile("/nonexistent/pac.pac", mockFs)
+
+    assertNull(result)
+}
+
+@Test
+fun `fetchPacFromFile returns null for non-readable path`() {
+    val mockFs = mockk<FileSystemIO>()
+    every { mockFs.exists(any()) } returns true
+    every { mockFs.isFile(any()) } returns true
+    every { mockFs.canRead(any()) } returns false
+
+    val resolver = ProxyResolver.withoutFileSupport(settingsRepository, jsEngine)
+    val result = resolver.fetchPacFromFile("/unreadable/pac.pac", mockFs)
+
+    assertNull(result)
+}
+
+@Test
+fun `fetchPacFromFile caches result and reuses within TTL`() {
+    val mockFs = mockk<FileSystemIO>()
+    every { mockFs.exists("/tmp/test.pac") } returns true
+    every { mockFs.isFile("/tmp/test.pac") } returns true
+    every { mockFs.canRead("/tmp/test.pac") } returns true
+    every { mockFs.readText("/tmp/test.pac") } returns "function FindProxyForURL(u, h) { return 'DIRECT'; }"
+
+    val resolver = ProxyResolver.withoutFileSupport(settingsRepository, jsEngine)
+
+      // Call twice within TTL — readText should only be called once (cached)
+    resolver.fetchPacFromFile("/tmp/test.pac", mockFs)
+    resolver.fetchPacFromFile("/tmp/test.pac", mockFs)
+
+    coVerify(exactly = 1) { mockFs.readText("/tmp/test.pac") }
+}
+
+@Test
+fun `fetchPacFromFile throws exception on read error`() {
+    val mockFs = mockk<FileSystemIO>()
+    every { mockFs.exists(any()) } returns true
+    every { mockFs.isFile(any()) } returns true
+    every { mockFs.canRead(any()) } returns true
+    every { mockFs.readText(any()) } throws RuntimeException("Permission denied")
+
+    val resolver = ProxyResolver.withoutFileSupport(settingsRepository, jsEngine)
+    val result = resolver.fetchPacFromFile("/error/pac.pac", mockFs)
+
+    assertNull(result)
+}
+```
+
+#### 9d. `BulkActionsRepositoryTest.kt` — Add tests (if repository layer testing is added)
+
+```kotlin
+@Test
+fun `expandTilde_expands_to_app_files_directory`() {
+    val original = "~/proxy.pac"
+      // Set appContext for BulkConfigParser first
+    val mockCtx = mockk<Context>(relaxed = true)
+    every { mockCtx.applicationContext.filesDir.absolutePath } returns "/data/user/0/app/files"
+    BulkConfigParser.appContext = mockCtx
+
+    val expanded = BulkConfigParser.expandTilde(original)
+    assertEquals("/data/user/0/app/files/proxy.pac", expanded)
+}
+
+@Test
+fun `expandTilde_returns_unchanged_when_no_tilde`() {
+    val original = "/sdcard/Downloads/proxy.pac"
+    val expanded = BulkConfigParser.expandTilde(original)
+    assertEquals(original, expanded)
+}
+```
+
+---
+
+## Files to Change (Summary)
+
+| File | Changes |
+|---|---|
+| `proxy/ProxyResolver.kt` | Add `FileSystemIO` interface + `DefaultFileSystemIO`; add `appContext: Context? = null` param to primary constructor; add `withoutFileSupport()` companion factory (deprecated); add `fetchPacFromFile()` (internal, @visibleForTesting); update `resolveProxy()` routing to dispatch by scheme |
+| **NEW** `PacSourceMode.kt` | New file: `enum class PacSourceMode { URL, FILE }` with `Default` companion |
+| `SettingsViewModel.kt` | Add `Context? appContext` param to constructor; add `pacSourceMode` to `SettingsUiState`; add `onPacSourceModeChange()` and `onPacFileSelected()` (copy-to-storage) actions; update `validatePacUrl()` for mode-aware validation; update `onProxyPacUrlChange()` to pass mode; factory → pass `appContext` |
+| `SettingsScreen.kt` | Add SAF launcher (`GetContent`); add segmented `FilterChip` toggle (URL/File); make PAC URL field mode-aware (label, placeholder, supporting text, trailing icon) |
+| **BulkConfig** (`BulkActionsRepository.kt`) | Add `fileProxyPac: String?` to data class; parse `file-proxypac` in BulkConfigParser; add mutual exclusion validation (`url-proxypac` + `file-proxypac`); add file existence check at parse time (skippable via `skipFileValidation`) |
+| `BulkConfigParser.kt` (in `BulkActionsRepository.kt`) | Add `@Volatile internal var skipFileValidation: Boolean = false`; add `file-proxypac` parsing + ~ expansion + validation |
+| `BulkActionsViewModel.kt` | Update proxy resolver setup calls to pass either `fileProxyPac` or `urlProxyPac` (whichever is non-null) |
+| **NEW** `GoogleTimeSyncViewModel.kt` | Add `Context? appContext` param to constructor; factory → pass `appContext` |
+| **NEW** `HttpsCertViewModel.kt` | Add `Context? appContext` param to constructor; factory → pass `appContext` |
+| **NEW** tests in `SettingsViewModelTest.kt` | ~16 new tests: source mode switching, file selection (copy-to-storage), validation (URL and FILE modes) |
+| **NEW** tests in `BulkConfigParserTest.kt` | 7 new tests: file-proxypac parsing, mutual exclusion error, blank/missing handling, tilde expansion, skipFileValidation flag |
+| **NEW** tests in `ProxyResolverTest.kt` | ~5 new tests: file-based PAC resolution with mocked `FileSystemIO` |
+
+---
+
+## Implementation Order
+
+1. **`proxy/ProxyResolver.kt`** — `FileSystemIO` interface + default impl, new primary constructor param `appContext`, `withoutFileSupport()` companion factory, `fetchPacFromFile()` (internal), routing in `resolveProxy()`
+2. **NEW `PacSourceMode.kt`** — Enum class creation
+3. **`SettingsViewModel.kt`** — `Context?` in constructor, `PacSourceMode` import, state field, mode switch action, file selection action (copy-to-storage), validation update, factory → pass `appContext`
+4. **`SettingsScreen.kt`** — SAF launcher, segmented toggle, mode-aware field
+5. **BulkActions files** — `fileProxyPac` field in BulkConfig, parsing in BulkConfigParser, mutual exclusion validation, file existence check + `skipFileValidation` flag; wire in BulkActionsViewModel
+6. **`GoogleTimeSyncViewModel.kt`** — Accept `Context?` in constructor, pass through factory
+7. **`HttpsCertViewModel.kt`** — Accept `Context?` in constructor, pass through factory
+8. **Tests** — SettingsViewModelTest (~16 tests), BulkConfigParserTest (~7 tests), ProxyResolverTest (~5 tests with FileSystemIO mock)
+
+---
+
+## Edge Cases & Considerations
+
+| Scenario | Handling |
+|---|---|
+| User selects a non-JS / non-PAC file | No MIME enforcement beyond picker hint. The JS engine will fail to evaluate and return null (same as invalid PAC content from HTTP). Safe fallback. |
+| File is deleted or permissions revoked after selection (Settings) | Copy-to-storage means the internal copy is independent of the source file. If user re-selects, a fresh copy overwrites. No stale reference risk. |
+| User switches between URL and File modes multiple times | Each switch clears the PAC URL/Path field and cache. Clean slate for new input. |
+| Large PAC files (e.g., corporate scripts > 1MB) | Copy via `inputStream.copyTo(outputStream)` through FileSystemIO — could be slow on large files. Existing read timeout is per-operation; file I/O has no explicit timeout but should complete within seconds for typical PAC scripts. |
+| Multiple PAC file selections in quick succession | Each selection triggers debounced save + cache clear (same as URL typing). No special handling needed. |
+| File path with spaces or special characters | `File()` handles these natively. SAF picker returns clean paths. No escaping needed. |
+| BulkActions config loaded via ADB push — file not on device | Parse-time validation throws `IllegalArgumentException` → shown as `ValidationMessage.Error` in UI. User sees clear message about missing file. (Unless `skipFileValidation = true` in tests.) |
+| User types `~/proxy.pac` in Settings file field | **No tilde expansion** — path stays literal (no expansion happens). Only BulkActions JSON configs get tilde expansion. |
+| BulkActions config with `~/proxy.pac` | Expands to app's private files dir (e.g., `/data/user/0/io.github.mobilutils.ntp_dig_ping_more/files/proxy.pac`) via existing `expandTilde()`. |
+| Settings ViewModel created without Context (e.g., manual test instantiation) | `appContext = null` → `onPacFileSelected()` fails gracefully, stores empty string + error message "Failed to copy". File mode is effectively disabled. URL mode still works. |
+| GoogleTimeSync / HttpsCert with file-based PAC from BulkActions | BulkActionsRepository.buildProxyResolver() uses `ProxyResolver.forStaticPacUrl(pacUrl, context, ...)` which passes Context → enables file routing. Works "out of the box" because `resolveProxy()` dispatches by scheme. |
+| GoogleTimeSync / HttpsCert with PAC URL from Settings | If user sets a PAC URL in Settings, then runs google-timesync or checkcert via BulkActions, the BulkActions config's `url-proxypac` / `file-proxypac` takes precedence (BulkActions creates its own ProxyResolver, not the one from Settings). |
+
+---
+
+## Not In Scope (Future Enhancements)
+
+- **Edit PAC content inline**: A text editor composable showing/fetching PAC script content for review
+- **PAC content hash caching**: Cache by file content hash instead of path string (handles re-selection of same file with different content, or file modifications in-place). Copy-to-storage already handles the "same file re-selected" case since we always overwrite.
+- **"Recent files" list**: Persist last N selected file paths/URIs for quick re-selection
+- **MIME type enforcement**: Strict checking that selected file is actually a JS/PAC file before accepting
+- **Permission restoration UI**: Explicit prompt if file access is revoked (currently fails silently as DIRECT)
+- **Symlink resolution**: Resolve symbolic links in file paths (Android rarely uses symlinks for user files, but corporate environments may)

--- a/notes/PROXY-PAC-IMPLEMENTATION.md
+++ b/notes/PROXY-PAC-IMPLEMENTATION.md
@@ -1,0 +1,577 @@
+# Proxy PAC Implementation
+
+## Overview
+
+The **Proxy PAC** feature allows the app to route outbound HTTP/HTTPS traffic through a proxy server determined by a [PAC (Proxy Auto-Config)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxy_server_configuration) JavaScript script. This is useful in corporate or restricted networks where outbound traffic must pass through a proxy.
+
+The system integrates with three network-based tools:
+- **HTTPS Certificate Inspector** — routes SSL/TLS connections via HTTP CONNECT tunneling
+- **Google Time Sync** — routes HTTP requests through the resolved proxy
+- **Bulk Actions** — supports per-batch `url-proxypac` in JSON configs, independent of persisted settings
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Settings Screen (UI)                          │
+│  ┌──────────────┐  ┌──────────────────┐  ┌────────────────┐   │
+│  │ Proxy Toggle  │  │   PAC URL Field  │  │ Test Proxy Btn │   │
+│  └──────┬───────┘  └────────┬─────────┘  └────────┬───────┘   │
+│         │                    │                       │            │
+└─────────┼────────────────────┼───────────────────────┼──────────┘
+          │                    │                       │
+          ▼                    ▼                       ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    SettingsViewModel                              │
+│  • onProxyEnabledChange()  → toggle + persist                  │
+│  • onProxyPacUrlChange()   → debounce (300ms) + validate      │
+│  • testProxy()             → launch connectivity test           │
+│  • validatePacUrl()        → http/https, non-empty host       │
+└───────────────────────┬─────────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                   SettingsRepository                               │
+│  • proxyConfigFlow: Flow<ProxyConfig>  (reactive DataStore)    │
+│  • saveProxyConfig(config)              (atomic save)           │
+└───────────────────────┬─────────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                     ProxyResolver                                  │
+│  • resolveProxy(targetUrl)  → Proxy?                            │
+│  • testProxy()              → ProxyTestResult                   │
+│  • clearCache()             → invalidate all caches             │
+│  • parsePacResult(pac)     → Proxy? (internal)                 │
+│  • fetchPacScript(url)     → String? (internal)                │
+│                                                                    │
+│  Two-level cache:                                                  │
+│  1. PAC Script Cache  (5-min TTL, @Volatile fields)             │
+│  2. Per-Host Proxy Cache (5-min TTL, synchronized map)          │
+└───┬──────────────────────────────┬──────────────────────────────┘
+    │                              │
+    ▼                              ▼
+┌──────────────────┐    ┌────────────────────────────────────┐
+│   JsEngine (I)   │    │  HttpURLConnection (PAC fetch)      │
+│  .evaluatePac()  │    │  GET pacUrl, 10s timeout           │
+└──────┬───────────┘    └────────────────────────────────────┘
+       │
+       ▼
+┌──────────────────┐
+│ QuickJsEngine    │
+│ (JsEngine impl)  │
+│ • Creates fresh  │
+│   QuickJs runtime│
+│ • Injects PAC    │
+│   utility stubs  │
+│ • Evaluates      │
+│   FindProxyForURL│
+│ • Closes runtime │
+└──────────────────┘
+```
+
+## Component Breakdown
+
+### 1. `JsEngine` (Interface)
+
+**File:** `app/src/main/java/.../proxy/JsEngine.kt`
+
+```kotlin
+interface JsEngine {
+    fun evaluatePac(pacScript: String, targetUrl: String, targetHost: String): String
+}
+```
+
+Abstraction over a JavaScript engine. Implementations must:
+- Be safe to call from `Dispatchers.IO`
+- Evaluate the standard `FindProxyForURL(url, host)` function
+- Return the raw PAC result string (e.g., `"PROXY 10.0.0.1:8080"`, `"DIRECT"`, or a semicolon-separated fallback chain)
+- Throw `Exception` if the script is malformed or evaluation fails
+
+### 2. `QuickJsEngine` (Concrete Implementation)
+
+**File:** `app/src/main/java/.../proxy/QuickJsEngine.kt`
+
+Backed by `app.cash.quickjs:quickjs-android-wrapper:0.9.2`.
+
+**Key design decision:** Each `evaluatePac()` call creates a **fresh** `QuickJs` runtime, evaluates, and tears it down in a `finally` block. This makes it safe for concurrent use — no shared mutable state between invocations.
+
+#### PAC Utility Stubs
+
+A minimal set of standard PAC helper functions is prepended to every evaluation so that common corporate PAC scripts work without a full browser environment:
+
+| Function | Implementation | Notes |
+|---|---|---|
+| `isPlainHostName(host)` | Returns `true` if `host` has no `.` | Full implementation |
+| `dnsDomainIs(host, domain)` | Checks if `host` ends with `domain` | Full implementation |
+| `localHostOrDomainIs(host, hostdom)` | Exact match or prefix match | Full implementation |
+| `isResolvable(host)` | Always returns `true` | Stubbed |
+| `isInNet(host, pattern, mask)` | Always returns `false` | Stubbed — would need real DNS |
+| `dnsResolve(host)` | Always returns `"127.0.0.1"` | Stubbed — would need Android DNS APIs |
+| `myIpAddress()` | Always returns `"127.0.0.1"` | Stubbed — would need network introspection |
+| `dnsDomainLevels(host)` | Counts `.`-separated segments minus 1 | Full implementation |
+| `shExpMatch(str, shexp)` | Converts shell glob to regex and tests | Full implementation |
+| `weekdayRange()` | Always returns `true` | Stubbed |
+| `dateRange()` | Always returns `true` | Stubbed |
+| `timeRange()` | Always returns `true` | Stubbed |
+
+**TODO in code:** Consider implementing real DNS resolution for `isInNet`/`dnsResolve` if corporate PAC scripts require accurate subnet matching.
+
+#### JS Escaping
+
+The `escapeJs()` method escapes `\` and `'` for safe embedding in JS string literals, preventing injection when URLs or hostnames contain special characters.
+
+#### Evaluation Flow
+
+```kotlin
+val engine = QuickJs.create()
+try {
+    engine.evaluate(PAC_UTILS)              // Inject utility stubs
+    engine.evaluate(pacScript)              // Load user's PAC script
+    val result = engine.evaluate(
+        "FindProxyForURL('$url', '$host');"
+    )
+    return result?.toString() ?: "DIRECT"
+} finally {
+    engine.close()                           // Always tear down
+}
+```
+
+### 3. `ProxyResolver` (Central Orchestrator)
+
+**File:** `app/src/main/java/.../proxy/ProxyResolver.kt`
+
+The core of the system. Fetches PAC scripts, evaluates them via `JsEngine`, and returns `java.net.Proxy` instances.
+
+#### Constructor
+
+```kotlin
+class ProxyResolver(
+    private val settingsRepository: SettingsRepository,
+    private val jsEngine: JsEngine,
+    private val staticPacUrl: String? = null,  // override for BulkActions
+)
+```
+
+- `settingsRepository` — source of persisted `ProxyConfig`
+- `jsEngine` — JS engine for PAC evaluation
+- `staticPacUrl` — when non-null, bypasses `SettingsRepository` and uses this URL directly (used by BulkActions)
+
+#### Constants
+
+| Constant | Value | Purpose |
+|---|---|---|
+| `PAC_CACHE_TTL_MS` | 300,000 ms (5 min) | TTL for PAC script and per-host caches |
+| `TEST_URL` | `http://connectivitycheck.gstatic.com/generate_204` | Google's connectivity-check endpoint |
+| `CONNECT_TIMEOUT_MS` | 10,000 ms | Connect timeout for PAC fetch and test |
+| `READ_TIMEOUT_MS` | 10,000 ms | Read timeout for PAC fetch and test |
+
+#### Factory Method for BulkActions
+
+```kotlin
+fun forStaticPacUrl(pacUrl: String, context: Context, jsEngine: JsEngine = QuickJsEngine()): ProxyResolver
+```
+
+Creates a resolver that uses a static PAC URL directly, without reading from or writing to `SettingsRepository`. This ensures that `url-proxypac` in a BulkActions JSON config does not affect the user's persisted proxy settings.
+
+#### Caching — Two Levels
+
+**Level 1: PAC Script Cache** (in-memory, 5-minute TTL)
+```kotlin
+@Volatile private var cachedPacScript: String? = null
+@Volatile private var cachedPacUrl: String? = null
+@Volatile private var pacFetchedAt: Long = 0L
+```
+
+If the same PAC URL is requested within 5 minutes, the cached script body is returned without network I/O.
+
+**Level 2: Per-Host Proxy Cache** (in-memory, 5-minute TTL)
+```kotlin
+private data class CachedProxy(val proxy: Proxy?, val resolvedAt: Long)
+private val proxyCache = mutableMapOf<String, CachedProxy>()
+```
+
+Keyed by hostname. Access is `synchronized(proxyCache)` for thread safety.
+
+#### `resolveProxy(targetUrl: String): Proxy?`
+
+The main public method. Flow:
+
+1. **Determine effective PAC URL:** uses `staticPacUrl` if set, otherwise reads from `settingsRepository.proxyConfigFlow.first()`
+2. **Early exit:** if proxy is disabled or PAC URL is blank, returns `null` (DIRECT)
+3. **Extract hostname** from the target URL via `extractHost()`
+4. **Check per-host cache:** if within TTL, return cached result immediately
+5. **Fetch PAC script:** uses script cache if within TTL, otherwise performs a `GET` request
+6. **Evaluate:** calls `jsEngine.evaluatePac(pacScript, targetUrl, host)` to get `FindProxyForURL` result
+7. **Parse:** converts the PAC result string into a `Proxy` via `parsePacResult()`
+8. **Cache and return:** stores result in per-host cache, returns the proxy
+9. **Error handling:** any failure at any step returns `null` (silent fallback to DIRECT)
+
+#### `testProxy(): ProxyTestResult`
+
+Connectivity test that:
+1. Calls `resolveProxy(TEST_URL)` to get a proxy
+2. Opens an `HttpURLConnection` (proxied or direct) to Google's `generate_204` endpoint
+3. Sends a `HEAD` request with 10s connect/read timeouts
+4. Returns `ProxyTestResult(success, message, latencyMs)`:
+   - On HTTP 2xx: success with latency and "via" info
+   - On non-2xx: failure with status code
+   - On exception: failure with exception message
+5. Always disconnects in `finally`
+
+#### `clearCache()`
+
+Clears both the PAC script cache and per-host proxy cache. Called when the user changes the PAC URL.
+
+#### `parsePacResult(pacResult: String): Proxy?`
+
+Internal method that parses PAC result strings:
+
+| PAC Result | Output |
+|---|---|
+| `"DIRECT"` | `null` |
+| `"PROXY host:port"` | `Proxy(Type.HTTP, InetSocketAddress)` |
+| `"SOCKS host:port"` | `Proxy(Type.SOCKS, InetSocketAddress)` |
+| `"SOCKS5 host:port"` | `Proxy(Type.SOCKS, InetSocketAddress)` |
+| `"SOCKS4 host:port"` | `Proxy(Type.SOCKS, InetSocketAddress)` |
+| `"PROXY a:1; PROXY b:2"` | First valid proxy (fallback chain) |
+| Empty/unknown directive | `null` (DIRECT) |
+
+- Case-insensitive directive matching
+- Port validation: must be 1..65535
+- Iterates semicolon-separated entries, returns first valid proxy or falls through to `null`
+
+#### `fetchPacScript(pacUrl: String): String?`
+
+Private helper:
+- Checks script cache first (same URL + within TTL)
+- Makes a `GET` request with 10s timeouts, follows redirects
+- On `HTTP_OK`, reads body as UTF-8, updates cache, returns script
+- On any error, returns `null`
+
+#### `extractHost(url: String): String?`
+
+Private helper:
+- Tries `URL(url).host` first
+- Falls back to manual stripping (`http://`, `https://`, then `/` and `:`) for non-standard strings
+
+### 4. `ProxyConfig` (Data Class)
+
+**File:** `app/src/main/java/.../settings/ProxyConfig.kt`
+
+```kotlin
+data class ProxyConfig(
+    val enabled: Boolean = false,
+    val pacUrl: String = "",
+    val lastTested: Long = 0L,
+    val lastTestResult: String? = null,
+)
+```
+
+Persisted in DataStore. Represents the user's proxy configuration.
+
+### 5. `SettingsDataStore` + `SettingsRepository`
+
+**Files:**
+- `app/src/main/java/.../settings/SettingsDataStore.kt`
+- `app/src/main/java/.../settings/SettingsRepository.kt`
+
+**DataStore preference keys:**
+
+| Key | Type | Preference Name |
+|---|---|---|
+| `PROXY_ENABLED` | `booleanPreferencesKey` | `"proxy_enabled"` |
+| `PROXY_PAC_URL` | `stringPreferencesKey` | `"proxy_pac_url"` |
+| `PROXY_LAST_TESTED` | `longPreferencesKey` | `"proxy_last_tested"` |
+| `PROXY_LAST_TEST_RESULT` | `stringPreferencesKey` | `"proxy_last_test_result"` |
+
+**Repository API:**
+```kotlin
+val proxyConfigFlow: Flow<ProxyConfig>       // reactive flow
+suspend fun saveProxyConfig(config: ProxyConfig)  // atomic save
+```
+
+`saveProxyConfig` handles null `lastTestResult` by removing the key from DataStore.
+
+### 6. `SettingsViewModel` (UI State Management)
+
+**File:** `app/src/main/java/.../SettingsViewModel.kt`
+
+Manages the Settings screen UI state with proxy-related fields in `SettingsUiState`:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `proxyEnabled` | `Boolean` | Whether proxy routing is active |
+| `proxyPacUrl` | `String` | Text in the PAC URL field |
+| `proxyPacUrlError` | `String?` | Inline validation error, or null if valid |
+| `isTestingProxy` | `Boolean` | True while a proxy test is in progress |
+| `proxyTestResult` | `String?` | Human-readable result of last test |
+| `proxyLastTested` | `Long` | Epoch millis of last test |
+
+**Key methods:**
+
+- **`onProxyEnabledChange(enabled: Boolean)`** — toggles proxy on/off, updates UI state immediately, persists via `saveCurrentProxyConfig()` in a coroutine
+
+- **`onProxyPacUrlChange(url: String)`** — called on every keystroke:
+  1. Updates `proxyPacUrl` immediately, clears `proxyPacUrlError` (UX: no error while typing)
+  2. Calls `proxyResolver.clearCache()` — invalidates PAC script and per-host caches
+  3. Cancels previous debounce job, starts a new one with **300ms delay**
+  4. After debounce: validates URL via `validatePacUrl(url)`
+  5. If valid (no error), persists via `saveCurrentProxyConfig()`
+
+- **`testProxy()`** — tests proxy connectivity:
+  1. Cancels any previous test job
+  2. Sets `isTestingProxy = true`
+  3. Launches coroutine calling `proxyResolver.testProxy()`
+  4. On completion: updates `proxyTestResult`, `proxyLastTested`, sets `isTestingProxy = false`
+  5. Persists test result to DataStore
+
+- **`validatePacUrl(url: String): String?`** — internal validation:
+  - Empty/blank URL → `null` (allowed, means "no proxy")
+  - Parses as `java.net.URL`
+  - Only `http://` and `https://` protocols allowed (FTP rejected)
+  - Host must be non-null and non-blank
+  - Returns error string on failure, `null` on success
+
+- **`saveCurrentProxyConfig()`** — private, persists current UI state as `ProxyConfig` to DataStore
+
+### 7. `SettingsScreen` (Compose UI)
+
+**File:** `app/src/main/java/.../SettingsScreen.kt`
+
+The proxy configuration section contains:
+
+1. **Enable/Disable toggle** — `Switch` bound to `uiState.proxyEnabled`, calls `viewModel::onProxyEnabledChange`
+2. **PAC URL input** — `OutlinedTextField` with:
+   - Placeholder: `"http://proxy.corp.com/proxy.pac"`
+   - Enabled only when `uiState.proxyEnabled` is `true`
+   - Error styling when `uiState.proxyPacUrlError != null`
+   - Keyboard type: `KeyboardType.Uri`
+3. **Test Proxy/PAC button** — `Button` that:
+   - Is enabled only when: proxy enabled, PAC URL non-blank, no validation error, not currently testing
+   - Shows `CircularProgressIndicator` while testing
+   - Calls `viewModel::testProxy`
+4. **Test result display** — shows the last test result in monospace font, color-coded green (success, starts with `✓`) or red (failure), with a formatted timestamp of last test
+
+---
+
+## Integration Points
+
+### GoogleTimeSyncRepository
+
+**File:** `app/src/main/java/.../GoogleTimeSyncRepository.kt`
+
+```kotlin
+class GoogleTimeSyncRepository(
+    private val proxyResolver: ProxyResolver? = null,
+)
+```
+
+In `fetchGoogleTime()`:
+```kotlin
+val proxy = proxyResolver?.resolveProxy(url)
+connection = if (proxy != null) {
+    URL(url).openConnection(proxy) as HttpURLConnection
+} else {
+    URL(url).openConnection() as HttpURLConnection
+}
+```
+
+Created via factory in `GoogleTimeSyncViewModel`:
+```kotlin
+val proxyResolver = ProxyResolver(settingsRepo, QuickJsEngine())
+return GoogleTimeSyncViewModel(
+    repository = GoogleTimeSyncRepository(proxyResolver),
+    ...
+)
+```
+
+### HttpsCertRepository
+
+**File:** `app/src/main/java/.../HttpsCertRepository.kt`
+
+```kotlin
+class HttpsCertRepository(
+    private val proxyResolver: ProxyResolver? = null,
+)
+```
+
+In `fetchCertificate()`:
+```kotlin
+val proxy = proxyResolver?.resolveProxy("https://$host:$port")
+socket = if (proxy != null && proxy.type() == Proxy.Type.HTTP) {
+    createProxiedSSLSocket(targetHost, targetPort, proxy, sslContext.socketFactory)
+} else {
+    // Direct connection (no proxy, or SOCKS)
+}
+```
+
+For **HTTP proxy**, it uses **HTTP CONNECT tunneling** via `createProxiedSSLSocket()`. For SOCKS proxy or no proxy, it connects directly.
+
+Created via factory in `HttpsCertViewModel`:
+```kotlin
+val proxyResolver = ProxyResolver(settingsRepo, QuickJsEngine())
+return HttpsCertViewModel(
+    repository = HttpsCertRepository(proxyResolver),
+    ...
+)
+```
+
+### BulkActionsRepository
+
+**File:** `app/src/main/java/.../BulkActionsRepository.kt`
+
+The `BulkConfig` data class has a `urlProxyPac: String?` field. When present:
+
+1. At the start of `executeCommands()`:
+   ```kotlin
+   bulkProxyResolver = config.urlProxyPac?.let { buildProxyResolver(it) }
+   ```
+
+2. `buildProxyResolver(pacUrl)` uses `ProxyResolver.forStaticPacUrl(pacUrl, context)` — bypasses persisted settings
+
+3. For `checkcert` pseudo-commands:
+   ```kotlin
+   val repo = bulkProxyResolver?.let { HttpsCertRepository(proxyResolver = it) } ?: certRepo
+   ```
+
+4. For `google-timesync` pseudo-commands:
+   ```kotlin
+   val repo = GoogleTimeSyncRepository(proxyResolver = bulkProxyResolver)
+   ```
+
+5. In the `finally` block of `executeCommands()`, `bulkProxyResolver` is set to `null` (cleanup)
+
+The `BulkActionsViewModel` also calls:
+- `repository.setupProxyResolver(config.urlProxyPac)` before execution
+- `repository.clearProxyResolver()` after execution
+
+This design ensures that the `url-proxypac` value in a JSON config is **scoped to that batch** and does not affect the user's persisted proxy settings.
+
+---
+
+## Error Handling Strategy
+
+The proxy system follows a **fail-silent, fall-through to DIRECT** pattern:
+
+| Failure Point | Behavior |
+|---|---|
+| Proxy disabled in settings | Returns `null` (DIRECT) |
+| PAC URL blank | Returns `null` (DIRECT) |
+| PAC script fetch fails (network error, non-200) | Returns `null` (DIRECT) |
+| JS evaluation throws | Returns `null` (DIRECT) |
+| PAC result is unparseable | Returns `null` (DIRECT) |
+| Port out of range (not 1..65535) | Skips to next entry in fallback chain |
+| `resolveProxy` outer try-catch | Catches all exceptions, returns `null` |
+
+The proxy feature is **non-blocking**: if anything goes wrong, the app simply uses a direct connection rather than failing the entire operation.
+
+---
+
+## Dependencies
+
+| Dependency | Version | Purpose |
+|---|---|---|
+| `app.cash.quickjs:quickjs-android-wrapper` | `0.9.2` | JS engine for PAC script evaluation |
+| `androidx.datastore:datastore-preferences` | `1.1.1` | Persistent storage for proxy config |
+
+Declared in:
+- `gradle/libs.versions.toml` (version catalog: `quickjs = "0.9.2"`)
+- `app/build.gradle.kts` (consumed as `implementation(libs.quickjs)`)
+
+---
+
+## Thread Safety
+
+| Component | Mechanism |
+|---|---|
+| PAC Script Cache | `@Volatile` fields on `cachedPacScript`, `cachedPacUrl`, `pacFetchedAt` |
+| Per-Host Proxy Cache | `synchronized(proxyCache)` on all read/write access |
+| QuickJsEngine | Fresh runtime per call — no shared state |
+| SettingsViewModel | Debounce job cancellation prevents concurrent validation |
+| ProxyResolver | `withContext(Dispatchers.IO)` for all suspend methods |
+
+---
+
+## Test Coverage
+
+### ProxyResolverTest.kt (18 tests)
+
+**`parsePacResult` — 14 tests:**
+- `DIRECT` returns `null`
+- `PROXY host:port` parses correctly (HTTP type)
+- `SOCKS host:port` parses correctly (SOCKS type)
+- `SOCKS5 host:port` parses correctly
+- Fallback chain: uses first valid entry
+- Fallback chain: skips malformed proxy, falls to DIRECT
+- Fallback chain: uses second proxy when first is malformed
+- Empty string returns `null`
+- Unknown directive returns `null`
+- Case-insensitive directive matching
+- Extra whitespace handling
+- Invalid port (99999) returns `null`
+- Missing port returns `null`
+
+**`resolveProxy` — 3 tests:**
+- Returns `null` when proxy is disabled
+- Returns `null` when PAC URL is blank
+- Returns `null` when JS engine throws
+
+**`clearCache` — 1 test:**
+- Does not throw
+
+Note: Network I/O (PAC script fetching) and JS evaluation are **mocked** in these tests.
+
+### SettingsViewModelTest.kt (18 proxy/PAC-related tests)
+
+- Initial state: proxy disabled, empty PAC URL
+- Loading persisted proxy config from DataStore
+- `onProxyEnabledChange` updates state and saves config
+- `validatePacUrl`: empty string (OK), valid HTTP (OK), valid HTTPS (OK), FTP (rejected), malformed URL (rejected), URL without host (rejected)
+- `onProxyPacUrlChange`: updates URL immediately, clears error while typing, clears proxy cache
+- `testProxy`: sets `isTestingProxy` during run, updates result on success/failure, saves to settings
+
+### BulkConfigParserTest.kt (4 tests for `url-proxypac`)
+
+- Parses `url-proxypac` value correctly
+- Returns `null` when key is absent
+- Returns `null` when value is blank string
+- Preserves `url-proxypac` alongside other config fields
+
+---
+
+## Known Limitations
+
+1. **Stubbed PAC functions:** `isInNet()`, `dnsResolve()`, `myIpAddress()`, `weekdayRange()`, `dateRange()`, and `timeRange()` return safe defaults rather than performing real operations. Corporate PAC scripts relying on subnet matching (`isInNet`) or time-based routing (`timeRange`) will not work correctly. A TODO comment in `QuickJsEngine.kt` notes this.
+
+2. **No SOCKS support for HTTPS cert inspection:** The `HttpsCertRepository` only tunnels through HTTP proxies (`Proxy.Type.HTTP`). SOCKS proxies fall through to a direct connection. This is by design — SOCKS tunneling over SSL requires additional socket-level handling.
+
+3. **In-memory cache only:** The PAC script and per-host proxy caches are in-memory only. They are lost on process death. This is acceptable given the 5-minute TTL and the fact that PAC URLs rarely change.
+
+4. **No proxy authentication:** The current implementation does not support proxy authentication (Basic/Digest). Corporate proxies requiring credentials will not work.
+
+5. **Single PAC URL:** The system supports a single PAC URL. It does not support fallback PAC URLs or multiple PAC scripts.
+
+---
+
+## File Index
+
+| File | Role |
+|---|---|
+| `proxy/JsEngine.kt` | Interface for JS evaluation |
+| `proxy/QuickJsEngine.kt` | QuickJS-based implementation of JsEngine |
+| `proxy/ProxyResolver.kt` | PAC fetch, cache, evaluate, resolve, test |
+| `settings/ProxyConfig.kt` | Data class for persisted proxy config |
+| `settings/SettingsDataStore.kt` | DataStore singleton + preference keys |
+| `settings/SettingsRepository.kt` | Reactive DataStore accessor |
+| `SettingsViewModel.kt` | ViewModel for Settings screen (proxy UI) |
+| `SettingsScreen.kt` | Compose UI for Settings (proxy section) |
+| `GoogleTimeSyncRepository.kt` | Uses ProxyResolver for Google Time Sync requests |
+| `GoogleTimeSyncViewModel.kt` | Factory creates ProxyResolver for GoogleTimeSyncRepository |
+| `HttpsCertRepository.kt` | Uses ProxyResolver for HTTPS cert inspection (HTTP CONNECT) |
+| `HttpsCertViewModel.kt` | Factory creates ProxyResolver for HttpsCertRepository |
+| `BulkActionsRepository.kt` | Uses static PAC URL for bulk command proxy routing |
+| `BulkActionsViewModel.kt` | Sets up and tears down proxy resolver for bulk execution |
+| `test/ProxyResolverTest.kt` | Unit tests for ProxyResolver |
+| `test/SettingsViewModelTest.kt` | Unit tests for SettingsViewModel (proxy/PAC) |
+| `test/BulkConfigParserTest.kt` | Unit tests for url-proxypac in JSON config |


### PR DESCRIPTION
Add file-based PAC script loading via SAF picker (SettingsScreen), with mutual exclusion validation against url-proxypac in Bulk Actions JSON configs. Expand test suite to 334 tests covering new ProxyResolver FileSystemIO abstraction, SettingsViewModel source mode switching, and BulkConfigParser file-proxypac parsing. Bump version to 3.0, update target SDK to 37.
