### PR TITLE
fix(bulk-actions): make config parse errors visible + fix file-proxypac handling

### DIFF
--- a/BULKACTIONS-ADB-SCRIPT.sh
+++ b/BULKACTIONS-ADB-SCRIPT.sh
@@ -166,6 +166,33 @@ echo "  Push path:      $PUSH_PATH"
 echo "  Results dir:    $RESULTS_DIR"
 echo "================================================================"
 
+# -- Helper: push a PAC file to app's private dir -------------------
+# When the config references a PAC file at /sdcard/..., copy it on-device
+# (the file exists on the device, not on the host). Returns the new path.
+push_pac_file() {
+    local pac_path="$1"
+       # Only handle /sdcard/ paths — HTTP(S) URLs are fetched over network
+    case "$pac_path" in
+          /sdcard/*)
+            local filename
+            filename="$(basename "$pac_path")"
+            local private_pac="$PRIVATE_DIR/$filename"
+               # Check if already present; skip copy if so
+            if ! adb shell "run-as $APP_ID test -f '$private_pac'" 2>/dev/null | grep -q "true"; then
+                echo "    Copying PAC file (on-device): $pac_path -> $private_pac" >&2
+                # File is on device — use adb shell cat to read it, pipe to run-as for writing
+                adb shell "cat '$pac_path'" | adb shell "run-as $APP_ID sh -c 'cat > $private_pac'" ||                     echo "    WARNING: Failed to copy PAC file to private dir." >&2
+            fi
+              # Print ONLY the result path to stdout (everything else goes to stderr)
+            echo "$private_pac"
+               ;;
+          *)
+            echo "$pac_path"
+               ;;
+    esac
+}
+
+
 # -- 1. Ensure emulator is running ----------------------------------
 if [ "$REAL_DEVICE" = true ]; then
     echo ""
@@ -199,16 +226,39 @@ else
     echo "[1/8] Device/emulator already running"
 fi
 
-# -- 2. Push config file to app's private directory -----------------
+# -- 2. Push config file + any referenced PAC files -----------------
 echo ""
 echo "[2/8] Pushing config file..."
+
+# Extract and push file-proxypac (if present) — the app can't read /sdcard/ directly
+PAC_PATH=$(json_str_field "$CONFIG_SOURCE" "file-proxypac")
+if [ -n "$PAC_PATH" ]; then
+    echo "  Resolving PAC file: $PAC_PATH"
+    PRIVATE_PAC_PATH=$(push_pac_file "$PAC_PATH")
+    if [ "$PRIVATE_PAC_PATH" != "$PAC_PATH" ]; then
+        echo "  PAC relocated to private dir: $PRIVATE_PAC_PATH"
+        # Rewrite the config JSON with the corrected PAC path before pushing
+        sed "s|$PAC_PATH|$PRIVATE_PAC_PATH|g" "$CONFIG_SOURCE" > "${CONFIG_SOURCE}.tmp"
+        CONFIG_TMP="${CONFIG_SOURCE}.tmp"
+    else
+        CONFIG_TMP="$CONFIG_SOURCE"
+    fi
+else
+    CONFIG_TMP="$CONFIG_SOURCE"
+fi
+
 # FIX 2 + 3: ADB cannot write directly to app's private dir (shell user has no permission).
 # Host-side cat pipes file content into a single adb shell that runs as the app's UID via run-as.
 # This avoids both the shell-user permission issue (push) and the /sdcard/ issue (run-as can't
 # read /sdcard because it runs in the app's mount namespace).
 # a substituted command would look like :
 # cat notes/config-files_bulk-actions/blkacts_single_ping_only.json | adb shell "run-as io.github.mobilutils.ntp_dig_ping_more sh -c 'cat > /data/user/0/io.github.mobilutils.ntp_dig_ping_more/files/blkacts_single_ping_only.json'"
-cat "$CONFIG_SOURCE" | adb shell "run-as $APP_ID sh -c 'cat > $PUSH_PATH'"
+cat "$CONFIG_TMP" | adb shell "run-as $APP_ID sh -c 'cat > $PUSH_PATH'"
+
+# Clean up temp file if we created one
+if [ "${CONFIG_TMP}" != "$CONFIG_SOURCE" ]; then
+    rm -f "${CONFIG_SOURCE}.tmp"
+fi
 
 # -- 3. Verify file was written -------------------------------------
 echo ""
@@ -316,7 +366,7 @@ if [ -n "$OUTPUT_FILE" ]; then
         DEVICE_OUTPUT_FILE="$OUTPUT_FILE"
     fi
 
-    TIMESTAMP=$(date '+%Y%m%d-%H:%M:%S')
+    TIMESTAMP=$(date '+%Y%m%d-%H%M%S')
     LOCAL_OUTPUT="$RESULTS_DIR/${TIMESTAMP}_$(basename "$DEVICE_OUTPUT_FILE")"
      # LOCAL_OUTPUT="$RESULTS_DIR/$(basename "$DEVICE_OUTPUT_FILE")"
 

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
@@ -186,16 +186,28 @@ object BulkConfigParser {
                     )
             }
 
-            // Validate file-proxypac exists and is readable (parse-time validation, skippable in tests)
+             // Validate file-proxypac exists and is readable (parse-time validation, skippable in tests)
         if (!fileProxyPac.isNullOrBlank() && !skipFileValidation) {
             val file = java.io.File(fileProxyPac)
-            if (!file.exists() || !file.isFile || !file.canRead()) {
+            if (!file.exists()) {
                 throw IllegalArgumentException(
-                            "file-proxypac points to inaccessible file: $fileProxyPac. " +
-                                "Ensure the file exists and is readable."
-                        )
-                    }
-            }
+                              "file-proxypac file not found: $fileProxyPac. " +
+                                  "Ensure the file exists and is readable by the app."
+                         )
+                     }
+            if (!file.canRead()) {
+                throw IllegalArgumentException(
+                              "file-proxypac is not readable: $fileProxyPac. " +
+                                  "The app cannot access /sdcard/Download/ directly. " +
+                                  "Solutions:\n" +
+                                  "   1. Move the .pac file to the app's private dir via ADB:\n" +
+                                  "     adb shell run-as io.github.mobilutils.ntp_dig_ping_more cp /sdcard/Download/factorized_proxy.pac files/\n" +
+                                  "     Then set \"file-proxypac\": \"files/factorized_proxy.pac\"\n" +
+                                  "   2. Use url-proxypac instead (HTTP/HTTPS URL).\n" +
+                                  "   3. When using the ADB script, it auto-copies /sdcard/ PAC files to the app's private dir."
+                         )
+                     }
+             }
 
         val logProxy: Boolean? = if (root.has("log-proxy")) {
             runCatching { root.optBoolean("log-proxy", false) }.getOrNull()
@@ -373,8 +385,9 @@ class BulkActionsRepository(
         cancellationToken: AtomicBoolean = AtomicBoolean(false),
         onProgress: ((BulkProgress) -> Unit)? = null,
     ): List<BulkCommandResult> {
-        // Set up proxy resolver from config-level PAC URL (if any)
-        bulkProxyResolver = config.urlProxyPac?.let {
+        // Set up proxy resolver from whichever PAC source is available (url or file)
+        val pacSource = config.urlProxyPac ?: config.fileProxyPac
+        bulkProxyResolver = pacSource?.let {
             buildProxyResolver(it, forceLogging = config.logProxy == true)
         }
 

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsScreen.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsScreen.kt
@@ -565,6 +565,82 @@ fun BulkActionsScreen(
             }
         }
 
+         // ── Config parse error (always visible when config failed to load) ──
+        AnimatedVisibility(
+            visible = !uiState.configLoaded && uiState.validationMessage is BulkActionsViewModel.ValidationMessage.Error,
+            enter = fadeIn(tween(200)),
+            exit = fadeOut(tween(200)),
+         ) {
+            val errorMsg = (uiState.validationMessage as? BulkActionsViewModel.ValidationMessage.Error)?.text ?: ""
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                 ),
+             ) {
+                Column(modifier = Modifier.padding(12.dp)) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                     ) {
+                        Icon(
+                            imageVector = Icons.Filled.Error,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onErrorContainer,
+                            modifier = Modifier.size(20.dp),
+                         )
+                        Text(
+                            text = "Config error",
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                         )
+                     }
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = errorMsg,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                     )
+                 }
+             }
+         }
+
+         // ── Config info (e.g. output-file fallback suggestion) ──
+        AnimatedVisibility(
+            visible = uiState.validationMessage is BulkActionsViewModel.ValidationMessage.Info,
+            enter = fadeIn(tween(200)),
+            exit = fadeOut(tween(200)),
+         ) {
+            val infoMsg = (uiState.validationMessage as? BulkActionsViewModel.ValidationMessage.Info)?.text ?: ""
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                 ),
+             ) {
+                Row(
+                    modifier = Modifier.padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                 ) {
+                    Icon(
+                        imageVector = Icons.Filled.Warning,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                        modifier = Modifier.size(20.dp),
+                     )
+                    Text(
+                        text = infoMsg,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onTertiaryContainer,
+                     )
+                 }
+             }
+         }
+
         // ── Error banner ──
         AnimatedVisibility(
             visible = uiState.outputFileWritten == false,

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/ProxyResolver.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/proxy/ProxyResolver.kt
@@ -128,6 +128,7 @@ class ProxyResolver(
             staticPacUrl = pacUrl,
             logger = logger,
             forceLogging = forceLogging,
+            appContext = context,
         )
 
         /**


### PR DESCRIPTION
When a JSON config failed to load (e.g. `file-proxypac` pointing to an inaccessible `/sdcard/` path), the error was silently swallowed — the "Run All Commands" button stayed grayed with no feedback shown.

**Now visible:**

- **Config parse errors** render as a red banner with actionable guidance (move PAC file, use `url-proxypac`, etc.)
- **Config info messages** (e.g. output-file fallback suggestion) render as a yellow warning banner
- Both banners are always visible regardless of `configLoaded` state

**Also fixes `file-proxypac` not working in three places:**

1. **`BulkActionsRepository.executeCommands()`** — only checked `urlProxyPac`, ignoring `fileProxyPac` entirely → now uses whichever is available
2. **`ProxyResolver.forStaticPacUrl()`** — received `Context` but never passed it as `appContext`, so `fetchPacFromFile()` always saw `appContext == null` → now passes `appContext = context` so file-based PAC scripts load
3. **`BULKACTIONS-ADB-SCRIPT.sh`** — now auto-copies `/sdcard/Download/*.pac` files to the app's private dir and rewrites the config JSON before pushing, so users can keep their PAC files in Download/ without manual intervention