### PR TITLE
Ghpages/screens page

### DIFF
--- a/docs/components/Img.tsx
+++ b/docs/components/Img.tsx
@@ -1,3 +1,24 @@
+/**
+ * Portable <img> that prepends BASE_PATH to image sources.
+ *
+ * When using `output: 'export'` (static export) with Next.js, the default
+ * `<Image>` component is incompatible — it requires the Image Optimization
+ * API which only runs in server mode (`next start`). Setting
+ * `unoptimized: true` allows `<Image>` to render as plain `<img>` tags,
+ * but Next.js does NOT prepend `basePath` to their `src` attributes at
+ * build time. The browser resolves `/images/foo.png` to the origin root
+ * (e.g. `https://mobilutils.github.io/images/...`) instead of the correct
+ * subpath (`https://mobilutils.github.io/ntp-dig-ping-more/images/...`).
+ *
+ * Nextra's markdown image syntax `![alt](/images/foo.png)` works because
+ * Nextra processes it at build time and rewrites paths with basePath.
+ * Plain HTML `<img>` tags have no such processing.
+ *
+ * This component bridges the gap: it reads `process.env.BASE_PATH` at
+ * build time and concatenates it with the image `src`, ensuring correct
+ * URLs in static-exported sites served under a subpath like GitHub Pages.
+ */
+
 const BASE_PATH = process.env.BASE_PATH || '';
 
 export default function Img({ src, alt, style, ...props }) {

--- a/docs/components/Img.tsx
+++ b/docs/components/Img.tsx
@@ -1,0 +1,5 @@
+const BASE_PATH = process.env.BASE_PATH || '';
+
+export default function Img({ src, alt, style, ...props }) {
+  return <img src={`${BASE_PATH}${src}`} alt={alt} style={style} {...props} />;
+}

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -9,8 +9,8 @@ export default withNextra({
     output: 'export',
     images: { unoptimized: true },
 
-    // 🎯 Important : basePath correspond au nom de votre repo GitHub
-    // Si votre repo est https://github.com/mobilutils/ntp-dig-ping-more → basePath: '/mon-projet'
-    // Si vous utilisez un domaine personnalisé → laissez ''
+     // 🎯 Important : basePath correspond au nom de votre repo GitHub
+     // Si votre repo est https://github.com/mobilutils/ntp-dig-ping-more → basePath: '/mon-projet'
+     // Si vous utilisez un domaine personnalisé → laissez ''
     basePath: process.env.BASE_PATH || '',
 })

--- a/docs/pages/available-features/screens.mdx
+++ b/docs/pages/available-features/screens.mdx
@@ -30,14 +30,14 @@ description: All screens available in the app.
 
   </div>
   <div style={{width: '50%' }}>
-    <img src="/images/1_screencap_ntp.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
+    <img src="./public/images/1_screencap_ntp.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
   </div>
 </div>
 
 
 <div style={{ display: 'flex', gap: '24px', alignItems: 'flex-start', marginBottom: '32px' }}>
     <div style={{ flex: 1 }}>
-    <img src="/images/2_screencap_dig.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
+    <img src="/public/images/2_screencap_dig.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
   </div>
   <div style={{ width: '50%' }} >
     <p><strong>DIG Domain Information Groper</strong></p>

--- a/docs/pages/available-features/screens.mdx
+++ b/docs/pages/available-features/screens.mdx
@@ -17,36 +17,36 @@ description: All screens available in the app.
 import Image from 'next/image'
 
 <div style={{ display: 'flex', gap: '24px', alignItems: 'flex-start', marginBottom: '32px' }}>
-  <div style={{ flex: 1 }}>
-    <p><strong>NTP Check</strong></p>
-    - Enter any NTP server address and port defaults to pool.ntp.org:123
+   <div style={{ flex: 1 }}>
+      <p><strong>NTP Check</strong></p>
+      - Enter any NTP server address and port defaults to pool.ntp.org:123
       Displays:
-      - ✅ / ❌ Reachability status
-      - Server Time
-      - Clock Offset (ms)
-      - Round-Trip Delay (ms)
-      
-    - Last 5 queries kept as clickable history (persisted across app restarts)
-    - Graceful error handling: DNS failure, timeout, no network
+        - ✅ / ❌ Reachability status
+        - Server Time
+        - Clock Offset (ms)
+        - Round-Trip Delay (ms)
 
-  </div>
-  <div style={{width: '50%' }}>
-    <Image src="/images/1_screencap_ntp.png" alt="NTP Check" width='300' height="400" style={{ maxWidth: '100%', height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
-  </div>
+      - Last 5 queries kept as clickable history (persisted across app restarts)
+      - Graceful error handling: DNS failure, timeout, no network
+
+   </div>
+   <div style={{width: '50%' }}>
+      <Image src="/images/1_screencap_ntp.png" alt="NTP Check" width='300' height="400" style={{ maxWidth: '100%', width: '100%', height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
+   </div>
 </div>
 
 
 <div style={{ display: 'flex', gap: '24px', alignItems: 'flex-start', marginBottom: '32px' }}>
-    <div style={{ flex: 1 }}>
-    <Image src="./public/images/2_screencap_dig.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
-  </div>
-  <div style={{ width: '50%' }} >
-    <p><strong>DIG Domain Information Groper</strong></p>
-    - DIG Test
-    - Enter a DNS server (IP or FQDN, e.g. `8.8.8.8`) and a name to resolve
-    - Query goes directly to the specified DNS server (API 29+), not the system resolver
-    - Displays a real `dig`-style answer section with aligned columns:
-    - Full CNAME chain resolution included
-    - Graceful error handling: NXDOMAIN, resolver unreachable, no network
-  </div>
+      <div style={{ flex: 1 }}>
+      <Image src="/images/2_screencap_dig.png" alt="DIG" width={300} height={400} style={{ maxWidth: '100%', width: '100%', height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
+   </div>
+   <div style={{ width: '50%' }} >
+      <p><strong>DIG Domain Information Groper</strong></p>
+      - DIG Test
+      - Enter a DNS server (IP or FQDN, e.g. `8.8.8.8`) and a name to resolve
+      - Query goes directly to the specified DNS server (API 29+), not the system resolver
+      - Displays a real `dig`-style answer section with aligned columns:
+      - Full CNAME chain resolution included
+      - Graceful error handling: NXDOMAIN, resolver unreachable, no network
+   </div>
 </div>

--- a/docs/pages/available-features/screens.mdx
+++ b/docs/pages/available-features/screens.mdx
@@ -31,14 +31,14 @@ import Image from 'next/image'
 
   </div>
   <div style={{width: '50%' }}>
-    <Image src={"/images/1_screencap_ntp.png"} alt="NTP Check" width='300' height="400" style={{ maxWidth: '100%', height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
+    <Image src="/images/1_screencap_ntp.png" alt="NTP Check" width='300' height="400" style={{ maxWidth: '100%', height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
   </div>
 </div>
 
 
 <div style={{ display: 'flex', gap: '24px', alignItems: 'flex-start', marginBottom: '32px' }}>
     <div style={{ flex: 1 }}>
-    <img src="./public/images/2_screencap_dig.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
+    <Image src="./public/images/2_screencap_dig.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
   </div>
   <div style={{ width: '50%' }} >
     <p><strong>DIG Domain Information Groper</strong></p>

--- a/docs/pages/available-features/screens.mdx
+++ b/docs/pages/available-features/screens.mdx
@@ -30,14 +30,14 @@ description: All screens available in the app.
 
   </div>
   <div style={{width: '50%' }}>
-    <img src="images/1_screencap_ntp.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
+    <img src="./images/1_screencap_ntp.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
   </div>
 </div>
 
 
 <div style={{ display: 'flex', gap: '24px', alignItems: 'flex-start', marginBottom: '32px' }}>
     <div style={{ flex: 1 }}>
-    <img src="2_screencap_dig.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
+    <img src="./public/images/2_screencap_dig.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
   </div>
   <div style={{ width: '50%' }} >
     <p><strong>DIG Domain Information Groper</strong></p>

--- a/docs/pages/available-features/screens.mdx
+++ b/docs/pages/available-features/screens.mdx
@@ -30,7 +30,7 @@ description: All screens available in the app.
 
   </div>
   <div style={{width: '50%' }}>
-    <img src="./images/1_screencap_ntp.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
+    <img src="/images/1_screencap_ntp.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
   </div>
 </div>
 

--- a/docs/pages/available-features/screens.mdx
+++ b/docs/pages/available-features/screens.mdx
@@ -31,7 +31,7 @@ import Image from 'next/image'
 
   </div>
   <div style={{width: '50%' }}>
-    <Image src="/images/1_screencap_ntp.png" alt="NTP Check" width='300' height="400" style={{ maxWidth: '100%', height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
+    <Image src={"/images/1_screencap_ntp.png"} alt="NTP Check" width='300' height="400" style={{ maxWidth: '100%', height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
   </div>
 </div>
 

--- a/docs/pages/available-features/screens.mdx
+++ b/docs/pages/available-features/screens.mdx
@@ -30,14 +30,14 @@ description: All screens available in the app.
 
   </div>
   <div style={{width: '50%' }}>
-    <img src="./public/images/1_screencap_ntp.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
+    <img src="images/1_screencap_ntp.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
   </div>
 </div>
 
 
 <div style={{ display: 'flex', gap: '24px', alignItems: 'flex-start', marginBottom: '32px' }}>
     <div style={{ flex: 1 }}>
-    <img src="/public/images/2_screencap_dig.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
+    <img src="2_screencap_dig.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
   </div>
   <div style={{ width: '50%' }} >
     <p><strong>DIG Domain Information Groper</strong></p>

--- a/docs/pages/available-features/screens.mdx
+++ b/docs/pages/available-features/screens.mdx
@@ -14,6 +14,7 @@ description: All screens available in the app.
 | ![Google Time Sync](/images/10_screencap_ggtimesync.png) | ![Check Cert](/images/11_screencap_checkcert.png) | ![Device Info](/images/12_screencap_deviceinfo.png) |
 
 ---
+import Image from 'next/image'
 
 <div style={{ display: 'flex', gap: '24px', alignItems: 'flex-start', marginBottom: '32px' }}>
   <div style={{ flex: 1 }}>
@@ -30,7 +31,7 @@ description: All screens available in the app.
 
   </div>
   <div style={{width: '50%' }}>
-    <img src="/images/1_screencap_ntp.png" alt="NTP Check" style={{ height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
+    <Image src="/images/1_screencap_ntp.png" alt="NTP Check" width='300' height="400" style={{ maxWidth: '100%', height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
   </div>
 </div>
 

--- a/docs/pages/available-features/screens.mdx
+++ b/docs/pages/available-features/screens.mdx
@@ -14,39 +14,38 @@ description: All screens available in the app.
 | ![Google Time Sync](/images/10_screencap_ggtimesync.png) | ![Check Cert](/images/11_screencap_checkcert.png) | ![Device Info](/images/12_screencap_deviceinfo.png) |
 
 ---
-import Image from 'next/image'
+import Img from '../../components/Img'
 
 <div style={{ display: 'flex', gap: '24px', alignItems: 'flex-start', marginBottom: '32px' }}>
-   <div style={{ flex: 1 }}>
-      <p><strong>NTP Check</strong></p>
-      - Enter any NTP server address and port defaults to pool.ntp.org:123
-      Displays:
+     <div style={{ flex: 1 }}>
+        <p><strong>NTP Check</strong></p>
+        - Enter any NTP server address and port defaults to pool.ntp.org:123
+        Displays:
         - ✅ / ❌ Reachability status
         - Server Time
         - Clock Offset (ms)
         - Round-Trip Delay (ms)
 
-      - Last 5 queries kept as clickable history (persisted across app restarts)
-      - Graceful error handling: DNS failure, timeout, no network
+        - Last 5 queries kept as clickable history (persisted across app restarts)
+        - Graceful error handling: DNS failure, timeout, no network
 
-   </div>
-   <div style={{width: '50%' }}>
-      <Image src="/images/1_screencap_ntp.png" alt="NTP Check" width='300' height="400" style={{ maxWidth: '100%', width: '100%', height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
-   </div>
+     </div>
+     <div style={{ width: '50%' }}>
+        <Img src="/images/1_screencap_ntp.png" alt="NTP Check" style={{ maxWidth: '100%', width: '100%', height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
+     </div>
 </div>
 
-
 <div style={{ display: 'flex', gap: '24px', alignItems: 'flex-start', marginBottom: '32px' }}>
-      <div style={{ flex: 1 }}>
-      <Image src="/images/2_screencap_dig.png" alt="DIG" width={300} height={400} style={{ maxWidth: '100%', width: '100%', height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
-   </div>
-   <div style={{ width: '50%' }} >
-      <p><strong>DIG Domain Information Groper</strong></p>
-      - DIG Test
-      - Enter a DNS server (IP or FQDN, e.g. `8.8.8.8`) and a name to resolve
-      - Query goes directly to the specified DNS server (API 29+), not the system resolver
-      - Displays a real `dig`-style answer section with aligned columns:
-      - Full CNAME chain resolution included
-      - Graceful error handling: NXDOMAIN, resolver unreachable, no network
-   </div>
+     <div style={{ flex: 1 }}>
+        <Img src="/images/2_screencap_dig.png" alt="DIG" style={{ maxWidth: '100%', width: '100%', height: 'auto', border: '1px solid #e5e7eb', borderRadius: '8px' }} />
+     </div>
+     <div style={{ width: '50%' }}>
+        <p><strong>DIG Domain Information Groper</strong></p>
+        - DIG Test
+        - Enter a DNS server (IP or FQDN, e.g. `8.8.8.8`) and a name to resolve
+        - Query goes directly to the specified DNS server (API 29+), not the system resolver
+        - Displays a real `dig`-style answer section with aligned columns:
+        - Full CNAME chain resolution included
+        - Graceful error handling: NXDOMAIN, resolver unreachable, no network
+     </div>
 </div>


### PR DESCRIPTION
1. The conflict: output: 'export' requires unoptimized: true, but Next.js doesn't prepend basePath to plain <img> src attributes
2. Why markdown works: Nextra processes ![alt](/path) at build time and rewrites paths
3. How the component solves it: Reads BASE_PATH at build time and concatenates it with the image src
