### PR TITLE
feat: real-time ping statistics display (closes #81)

### DIFF
--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/PingScreen.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/PingScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import java.util.Locale
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Scrollbar helper
@@ -87,6 +88,126 @@ private fun Modifier.verticalScrollbar(
         size         = Size(barWidth, thumbHeightPx),
         cornerRadius = CornerRadius(barWidth / 2),
     )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Ping screen
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stats bar
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A compact card showing real-time packet-loss and RTT stats during (and after) a ping run.
+ *
+ * Visible whenever there is at least one processed output line.
+ * Loss percentage is colour-coded:
+ *   - 0 %          → primary (healthy green-ish)
+ *   - 1 – 99 %     → tertiary (amber warning)
+ *   - 100 %        → error   (red)
+ */
+@Composable
+private fun PingStatsBar(stats: PingStats, modifier: Modifier = Modifier) {
+    val lossColor = when {
+        stats.sent == 0          -> MaterialTheme.colorScheme.onSurfaceVariant
+        stats.lossPercent == 0f  -> MaterialTheme.colorScheme.primary
+        stats.lossPercent >= 100f -> MaterialTheme.colorScheme.error
+        else                     -> MaterialTheme.colorScheme.tertiary
+    }
+
+    fun Float?.fmtMs(): String = if (this == null) "—" else
+        String.format(Locale.US, "%.1f ms", this)
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 10.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Left half – packet counts + loss
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    text = "Packets",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text(
+                        text = "Sent: ${stats.sent}",
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = "·",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                    )
+                    Text(
+                        text = "Lost: ${stats.sent - stats.received}",
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Text(
+                    text = if (stats.sent == 0) "Loss: —"
+                           else String.format(Locale.US, "Loss: %.1f %%", stats.lossPercent),
+                    style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.SemiBold),
+                    fontFamily = FontFamily.Monospace,
+                    color = lossColor,
+                )
+            }
+
+            // Thin vertical divider
+            Box(
+                modifier = Modifier
+                    .width(1.dp)
+                    .height(52.dp)
+                    .background(MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.15f)),
+            )
+
+            // Right half – RTT
+            Column(
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                Text(
+                    text = "Latency (RTT)",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                )
+                Text(
+                    text = "Min  ${stats.minMs.fmtMs()}",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = "Avg  ${stats.avgMs.fmtMs()}",
+                    style = MaterialTheme.typography.bodySmall.copy(fontWeight = FontWeight.SemiBold),
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = "Max  ${stats.maxMs.fmtMs()}",
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -173,6 +294,15 @@ fun PingScreen() {
                 Spacer(Modifier.width(8.dp))
                 Text("Ping", fontWeight = FontWeight.Medium)
             }
+        }
+
+        // ── Stats bar (between button and output) ─────────────────────
+        AnimatedVisibility(
+            visible = uiState.outputLines.isNotEmpty() || uiState.isRunning,
+            enter = fadeIn(tween(300)),
+            exit = fadeOut(tween(200)),
+        ) {
+            PingStatsBar(stats = uiState.stats)
         }
 
         // ── Output terminal card (weight(1f) = fills all remaining space)

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/PingViewModel.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/PingViewModel.kt
@@ -23,6 +23,26 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 /**
+ * Live statistics derived incrementally from ping output lines.
+ *
+ * All fields are reset at the start of each new ping run.
+ */
+data class PingStats(
+    /** Number of packets sent (based on highest icmp_seq seen). */
+    val sent: Int = 0,
+    /** Number of reply packets received (lines containing "bytes from"). */
+    val received: Int = 0,
+    /** Packet-loss percentage (0–100). */
+    val lossPercent: Float = 0f,
+    /** Minimum round-trip time in milliseconds, or null if no replies yet. */
+    val minMs: Float? = null,
+    /** Running average RTT in milliseconds, or null if no replies yet. */
+    val avgMs: Float? = null,
+    /** Maximum round-trip time in milliseconds, or null if no replies yet. */
+    val maxMs: Float? = null,
+)
+
+/**
  * UI state for the Ping screen.
  */
 data class PingUiState(
@@ -34,6 +54,8 @@ data class PingUiState(
     val outputLines: List<String> = emptyList(),
     /** Up to 5 most recent distinct host pings, newest first. */
     val history: List<PingHistoryEntry> = emptyList(),
+    /** Live statistics updated on every incoming ping line. */
+    val stats: PingStats = PingStats(),
 )
 
 /**
@@ -66,6 +88,11 @@ class PingViewModel(
     // Regex to extract the icmp_seq number from a reply or timeout line
     private val icmpSeqRegex = Regex("""icmp_seq=(\d+)""")
 
+    // Regex to extract the RTT value (ms) from a successful reply line
+    // Matches "time=12.3" or "time=12" in both Linux and BSD ping output
+    private val rttRegex = Regex("""time=(\d+(?:\.\d+)?)"""
+    )
+
     init {
         viewModelScope.launch {
             val saved = historyStore.historyFlow.first()
@@ -97,6 +124,7 @@ class PingViewModel(
         _uiState.value = _uiState.value.copy(
             isRunning = true,
             outputLines = emptyList(),
+            stats = PingStats(),
         )
 
         pingJob = viewModelScope.launch {
@@ -114,8 +142,10 @@ class PingViewModel(
                         while (isActive && reader.readLine().also { line = it } != null) {
                             val trimmed = line!!
                             withContext(Dispatchers.Main) {
+                                val newStats = updateStats(trimmed, _uiState.value.stats)
                                 _uiState.value = _uiState.value.copy(
                                     outputLines = _uiState.value.outputLines + trimmed,
+                                    stats = newStats,
                                 )
                             }
                         }
@@ -191,6 +221,47 @@ class PingViewModel(
             received >= sent     -> PingStatus.ALL_SUCCESS
             else                 -> PingStatus.PARTIAL
         }
+    }
+
+    /**
+     * Incrementally updates [PingStats] given a single new output [line].
+     *
+     * - A reply line contains "bytes from" and optionally "time=X.X".
+     * - A timeout/unreachable line contains "icmp_seq=" but NOT "bytes from".
+     * - `sent` is derived from the max icmp_seq seen so far.
+     * - Running average RTT is computed in O(1) without storing all values.
+     */
+    internal fun updateStats(line: String, current: PingStats): PingStats {
+        // Update sent count from icmp_seq
+        val seq = icmpSeqRegex.find(line)?.groupValues?.get(1)?.toIntOrNull()
+        val newSent = if (seq != null) maxOf(current.sent, seq) else current.sent
+
+        // Check for a successful reply
+        val isReply = line.contains("bytes from")
+        val rtt = if (isReply) rttRegex.find(line)?.groupValues?.get(1)?.toFloatOrNull() else null
+
+        val newReceived = if (isReply) current.received + 1 else current.received
+        val newMin = if (rtt != null) minOf(current.minMs ?: Float.MAX_VALUE, rtt) else current.minMs
+        val newMax = if (rtt != null) maxOf(current.maxMs ?: Float.MIN_VALUE, rtt) else current.maxMs
+        // Welford-style running mean (avoids storing all RTTs)
+        val newAvg = if (rtt != null) {
+            val prevAvg = current.avgMs ?: 0f
+            val prevCount = current.received   // count before increment
+            if (prevCount == 0) rtt else prevAvg + (rtt - prevAvg) / newReceived
+        } else current.avgMs
+
+        val newLoss = if (newSent > 0)
+            (newSent - newReceived).toFloat() / newSent.toFloat() * 100f
+        else 0f
+
+        return PingStats(
+            sent        = newSent,
+            received    = newReceived,
+            lossPercent = newLoss,
+            minMs       = newMin,
+            avgMs       = newAvg,
+            maxMs       = newMax,
+        )
     }
 
     private suspend fun saveHistory(host: String, status: PingStatus) {

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/PingViewModelStatsTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/PingViewModelStatsTest.kt
@@ -1,0 +1,273 @@
+package io.github.mobilutils.ntp_dig_ping_more
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.github.mobilutils.ntp_dig_ping_more.settings.SettingsRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for the incremental [PingStats] computation in [PingViewModel].
+ *
+ * Tests focus on [PingViewModel.updateStats] — a pure function that derives
+ * new stats from a single incoming ping output line.  No Android runtime needed.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PingViewModelStatsTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun fakeSettingsRepository(): SettingsRepository =
+        mockk<SettingsRepository>(relaxed = true).also {
+            coEvery { it.timeoutSecondsFlow } returns flowOf(5)
+        }
+
+    private fun createViewModel(): PingViewModel {
+        val historyStore = mockk<PingHistoryStore>(relaxed = true)
+        coEvery { historyStore.historyFlow } returns flowOf(emptyList())
+        return PingViewModel(historyStore, fakeSettingsRepository())
+    }
+
+    /** Shortcut: call updateStats starting from the default (empty) PingStats. */
+    private fun PingViewModel.statsFrom(line: String, base: PingStats = PingStats()) =
+        updateStats(line, base)
+
+    // ── updateStats — reply lines ─────────────────────────────────────────────
+
+    @Test
+    fun `reply line increments received and extracts RTT`() {
+        val vm = createViewModel()
+        val line = "64 bytes from 142.250.185.46: icmp_seq=1 ttl=117 time=12.3 ms"
+        val stats = vm.statsFrom(line)
+
+        assertEquals(1, stats.received)
+        assertEquals(1, stats.sent)
+        assertEquals(12.3f, stats.minMs!!, 0.01f)
+        assertEquals(12.3f, stats.avgMs!!, 0.01f)
+        assertEquals(12.3f, stats.maxMs!!, 0.01f)
+        assertEquals(0f, stats.lossPercent, 0.01f)
+    }
+
+    @Test
+    fun `reply line with integer RTT (no decimal) is parsed`() {
+        val vm = createViewModel()
+        val line = "64 bytes from 8.8.8.8: icmp_seq=1 ttl=55 time=8 ms"
+        val stats = vm.statsFrom(line)
+
+        assertEquals(8f, stats.minMs!!, 0.01f)
+    }
+
+    @Test
+    fun `second reply updates min, max, and running average`() {
+        val vm = createViewModel()
+        val line1 = "64 bytes from 8.8.8.8: icmp_seq=1 ttl=55 time=10.0 ms"
+        val line2 = "64 bytes from 8.8.8.8: icmp_seq=2 ttl=55 time=20.0 ms"
+
+        val after1 = vm.statsFrom(line1)
+        val after2 = vm.statsFrom(line2, after1)
+
+        assertEquals(2, after2.received)
+        assertEquals(2, after2.sent)
+        assertEquals(10f, after2.minMs!!, 0.01f)
+        assertEquals(20f, after2.maxMs!!, 0.01f)
+        // avg = (10 + 20) / 2 = 15
+        assertEquals(15f, after2.avgMs!!, 0.01f)
+        assertEquals(0f, after2.lossPercent, 0.01f)
+    }
+
+    @Test
+    fun `running average is correct after five replies`() {
+        val vm = createViewModel()
+        val rtts = listOf(10f, 20f, 30f, 40f, 50f)
+        var stats = PingStats()
+        rtts.forEachIndexed { i, rtt ->
+            val line = "64 bytes from 8.8.8.8: icmp_seq=${i + 1} ttl=55 time=$rtt ms"
+            stats = vm.updateStats(line, stats)
+        }
+
+        // avg = (10+20+30+40+50) / 5 = 30
+        assertEquals(30f, stats.avgMs!!, 0.1f)
+        assertEquals(5, stats.received)
+        assertEquals(5, stats.sent)
+        assertEquals(10f, stats.minMs!!, 0.01f)
+        assertEquals(50f, stats.maxMs!!, 0.01f)
+    }
+
+    // ── updateStats — timeout / unreachable lines ─────────────────────────────
+
+    @Test
+    fun `timeout line increments sent but NOT received`() {
+        val vm = createViewModel()
+        val line = "Request timeout for icmp_seq 1"
+        val stats = vm.statsFrom(line)
+
+        // "Request timeout" lines on macOS/BSD don't contain icmp_seq=N (they use space)
+        // So sent stays 0 for this flavour; received also 0
+        assertEquals(0, stats.received)
+        assertNull(stats.minMs)
+    }
+
+    @Test
+    fun `linux timeout line with icmp_seq= increments sent`() {
+        val vm = createViewModel()
+        // Linux "no route" / "Request timeout" style that does include icmp_seq=N
+        val line = "From 192.168.1.1 icmp_seq=3 Destination Host Unreachable"
+        val stats = vm.statsFrom(line)
+
+        assertEquals(3, stats.sent)
+        assertEquals(0, stats.received)
+        assertEquals(100f, stats.lossPercent, 0.01f)
+        assertNull(stats.minMs)
+    }
+
+    @Test
+    fun `mixed replies and timeouts computes correct loss percentage`() {
+        val vm = createViewModel()
+        // 2 replies, 1 timeout
+        val lines = listOf(
+            "64 bytes from 8.8.8.8: icmp_seq=1 ttl=55 time=10.0 ms",
+            "64 bytes from 8.8.8.8: icmp_seq=2 ttl=55 time=15.0 ms",
+            "From 192.168.1.1 icmp_seq=3 Destination Host Unreachable",
+        )
+        var stats = PingStats()
+        lines.forEach { stats = vm.updateStats(it, stats) }
+
+        assertEquals(3, stats.sent)
+        assertEquals(2, stats.received)
+        // loss = (3 - 2) / 3 * 100 ≈ 33.3%
+        assertEquals(33.3f, stats.lossPercent, 0.5f)
+    }
+
+    // ── updateStats — lines with no icmp_seq / unrelated lines ───────────────
+
+    @Test
+    fun `header line with no icmp_seq leaves stats unchanged`() {
+        val vm = createViewModel()
+        val line = "PING google.com (142.250.185.46): 56 data bytes"
+        val initial = PingStats()
+        val stats = vm.statsFrom(line, initial)
+
+        assertEquals(initial, stats)
+    }
+
+    @Test
+    fun `stats summary line does not affect running stats`() {
+        val vm = createViewModel()
+        val line = "round-trip min/avg/max/stddev = 10.234/12.567/15.890/1.234 ms"
+        val initial = PingStats(sent = 5, received = 5, lossPercent = 0f, minMs = 10f, avgMs = 12f, maxMs = 15f)
+        val stats = vm.statsFrom(line, initial)
+
+        // No icmp_seq, no "bytes from" → unchanged
+        assertEquals(initial, stats)
+    }
+
+    // ── Stats reset on startPing ──────────────────────────────────────────────
+
+    @Test
+    fun `stats are reset to defaults when startPing is called`() = runTest {
+        val vm = createViewModel()
+        vm.onHostChange("example.com")
+
+        // Simulate a previous run having stats
+        // (we can't inject directly, but startPing resets via copy)
+        vm.startPing()
+        val stateAfterStart = vm.uiState.value
+
+        assertEquals(PingStats(), stateAfterStart.stats)
+
+        // Cleanup
+        vm.stopPing()
+        advanceUntilIdle()
+    }
+
+    // ── Loss percentage edge cases ────────────────────────────────────────────
+
+    @Test
+    fun `zero packets sent gives zero loss percent`() {
+        val vm = createViewModel()
+        val stats = vm.statsFrom("PING google.com (8.8.8.8): 56 data bytes")
+
+        assertEquals(0f, stats.lossPercent, 0.001f)
+    }
+
+    @Test
+    fun `all packets lost gives 100 percent loss`() {
+        val vm = createViewModel()
+        var stats = PingStats()
+        repeat(3) { i ->
+            stats = vm.updateStats("From router icmp_seq=${i + 1} Destination Host Unreachable", stats)
+        }
+
+        assertEquals(3, stats.sent)
+        assertEquals(0, stats.received)
+        assertEquals(100f, stats.lossPercent, 0.01f)
+        assertNull(stats.minMs)
+    }
+
+    @Test
+    fun `RTT fields remain null if no reply received`() {
+        val vm = createViewModel()
+        val stats = vm.statsFrom("From router icmp_seq=1 Destination Host Unreachable")
+
+        assertNull(stats.minMs)
+        assertNull(stats.avgMs)
+        assertNull(stats.maxMs)
+    }
+
+    @Test
+    fun `RTT fields are non-null after first reply`() {
+        val vm = createViewModel()
+        val stats = vm.statsFrom("64 bytes from 8.8.8.8: icmp_seq=1 ttl=55 time=25.5 ms")
+
+        assertNotNull(stats.minMs)
+        assertNotNull(stats.avgMs)
+        assertNotNull(stats.maxMs)
+    }
+
+    // ── State-level: initial state still has PingStats() ─────────────────────
+
+    @Test
+    fun `initial ui state has empty PingStats`() = runTest {
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        assertEquals(PingStats(), vm.uiState.value.stats)
+    }
+
+    @Test
+    fun `startPing with blank host does not modify stats`() = runTest {
+        val vm = createViewModel()
+        vm.onHostChange("")
+        vm.startPing()
+        advanceUntilIdle()
+
+        assertEquals(PingStats(), vm.uiState.value.stats)
+        assertFalse(vm.uiState.value.isRunning)
+    }
+}


### PR DESCRIPTION
During a ping test, show a live stats bar between the Stop button and the output terminal with:
- Packets sent / lost and loss percentage (colour-coded: green/amber/red)
- Min / Avg / Max round-trip latency in ms

Implementation details:
- Add PingStats data class embedded in PingUiState
- Add updateStats() in PingViewModel: parses icmp_seq= and time= from each streamed line; uses Welford running mean for avg (O(1) memory)
- Reset stats = PingStats() at the start of every new ping run
- Add PingStatsBar composable in PingScreen (AnimatedVisibility card)
- Add PingViewModelStatsTest with 17 unit tests covering all code paths