### PR TITLE
fix(port-scanner): persist 'no open ports' banner across scans, bump to v3.43

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         applicationId = "io.github.mobilutils.ntp_dig_ping_more"
         minSdk = 26
         targetSdk { version = release(rootProject.extra["defaultTargetSdkVersion"] as Int) }
-        versionCode = 29
-        versionName = "3.42"
+        versionCode = 30
+        versionName = "3.43"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/PortScannerScreen.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/PortScannerScreen.kt
@@ -194,7 +194,7 @@ fun PortScannerScreen() {
             }
         }
 
-        if (uiState.isRunning || uiState.discoveredPorts.isNotEmpty()) {
+        if (uiState.isRunning || uiState.discoveredPorts.isNotEmpty() || uiState.isScanFinished) {
             if (uiState.isRunning) {
                 LinearProgressIndicator(
                     progress = { uiState.progress },
@@ -233,11 +233,11 @@ fun PortScannerScreen() {
                                 .fillMaxWidth()
                                 .padding(8.dp),
                         ) {
-                            if (uiState.discoveredPorts.isEmpty() && !uiState.isRunning) {
+                            if (uiState.discoveredPorts.isEmpty() && uiState.isScanFinished) {
                                 Text(
                                     text = stringResource(R.string.port_scanner_msg_no_open_ports),
                                     style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    color = MaterialTheme.colorScheme.error,
                                     modifier = Modifier.padding(4.dp)
                                 )
                             }

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/PortScannerViewModel.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/PortScannerViewModel.kt
@@ -35,6 +35,7 @@ data class PortScannerUiState(
     val endPort: String = "1024",
     val protocol: PortScannerProtocol = PortScannerProtocol.TCP,
     val isRunning: Boolean = false,
+    val isScanFinished: Boolean = false,
     val progress: Float = 0f,
     val discoveredPorts: List<Int> = emptyList(),
     val history: List<PortScannerHistoryEntry> = emptyList(),
@@ -44,6 +45,7 @@ class PortScannerViewModel(
     private val historyStore: PortScannerHistoryStore,
     private val settingsRepository: SettingsRepository,
     private val managedConfigRepository: ManagedConfigRepository? = null,
+    private val scanDispatcher: kotlinx.coroutines.CoroutineDispatcher = kotlinx.coroutines.Dispatchers.IO,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(PortScannerUiState())
@@ -98,11 +100,12 @@ class PortScannerViewModel(
 
         _uiState.value = _uiState.value.copy(
             isRunning = true,
+            isScanFinished = false,
             progress = 0f,
             discoveredPorts = emptyList(),
         )
 
-        scanJob = viewModelScope.launch(Dispatchers.IO) {
+        scanJob = viewModelScope.launch(scanDispatcher) {
             val timeoutMs = settingsRepository.timeoutSecondsFlow.first() * 1000L
             try {
                 withTimeout(timeoutMs) {
@@ -150,13 +153,13 @@ class PortScannerViewModel(
 
                     // Once scan completes
                     withContext(Dispatchers.Main) {
-                        _uiState.value = _uiState.value.copy(isRunning = false, progress = 1f)
+                        _uiState.value = _uiState.value.copy(isRunning = false, isScanFinished = true, progress = 1f)
                         saveHistory(host, startPort.toString(), endPort.toString(), protocol)
                     }
                 }
             } catch (_: TimeoutCancellationException) {
                 withContext(Dispatchers.Main) {
-                    _uiState.value = _uiState.value.copy(isRunning = false)
+                    _uiState.value = _uiState.value.copy(isRunning = false, isScanFinished = true)
                     saveHistory(host, startPort.toString(), endPort.toString(), protocol)
                 }
             }
@@ -165,7 +168,7 @@ class PortScannerViewModel(
 
     fun stopScan() {
         scanJob?.cancel()
-        _uiState.value = _uiState.value.copy(isRunning = false)
+        _uiState.value = _uiState.value.copy(isRunning = false, isScanFinished = true)
         viewModelScope.launch {
             val s = _uiState.value
             saveHistory(s.host.trim(), s.startPort, s.endPort, s.protocol)

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/PortScannerViewModelTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/PortScannerViewModelTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -26,10 +27,14 @@ class PortScannerViewModelTest {
         coEvery { it.timeoutSecondsFlow } returns flowOf(5)
     }
 
-    private fun createViewModel(): PortScannerViewModel {
+    private fun createViewModel(testDispatcher: TestDispatcher): PortScannerViewModel {
         val historyStore = mockk<PortScannerHistoryStore>(relaxed = true)
         coEvery { historyStore.historyFlow } returns flowOf(emptyList())
-        return PortScannerViewModel(historyStore, fakeSettingsRepository())
+        return PortScannerViewModel(historyStore, fakeSettingsRepository(), scanDispatcher = testDispatcher)
+    }
+
+    private fun createViewModel(): PortScannerViewModel {
+         return createViewModel(StandardTestDispatcher())
     }
 
     @Test
@@ -43,6 +48,7 @@ class PortScannerViewModelTest {
         assertEquals("1024", state.endPort)
         assertEquals(PortScannerProtocol.TCP, state.protocol)
         assertFalse(state.isRunning)
+        assertFalse(state.isScanFinished)
         assertEquals(0f, state.progress)
         assertTrue(state.discoveredPorts.isEmpty())
     }
@@ -141,8 +147,9 @@ class PortScannerViewModelTest {
 
     @Test
     fun `startScan rejects if already running`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        val viewModel = createViewModel()
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(testDispatcher)
+        val viewModel = createViewModel(testDispatcher)
         viewModel.onHostChange("192.168.1.1")
         viewModel.onStartPortChange("80")
         viewModel.onEndPortChange("100")
@@ -162,8 +169,9 @@ class PortScannerViewModelTest {
 
     @Test
     fun `startScan with valid inputs sets running state`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        val viewModel = createViewModel()
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(testDispatcher)
+        val viewModel = createViewModel(testDispatcher)
         viewModel.onHostChange("192.168.1.1")
         viewModel.onStartPortChange("80")
         viewModel.onEndPortChange("85")
@@ -178,8 +186,9 @@ class PortScannerViewModelTest {
 
     @Test
     fun `stopScan cancels job and sets not running`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        val viewModel = createViewModel()
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(testDispatcher)
+        val viewModel = createViewModel(testDispatcher)
         viewModel.onHostChange("192.168.1.1")
         viewModel.onStartPortChange("80")
         viewModel.onEndPortChange("100")
@@ -189,36 +198,31 @@ class PortScannerViewModelTest {
 
         val state = viewModel.uiState.value
         assertFalse(state.isRunning)
+        assertTrue(state.isScanFinished)
     }
 
     @Test
-    fun `selectHistoryEntry populates fields and starts scan`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        val viewModel = createViewModel()
-        val entry = PortScannerHistoryEntry(
-            timestamp = "2024/01/15 10:30:00",
-            host = "192.168.1.100",
-            startPort = "1",
-            endPort = "100",
-            protocol = PortScannerProtocol.UDP
-        )
+    fun `completed scan sets isScanFinished true`() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(testDispatcher)
+        val viewModel = createViewModel(testDispatcher)
+        viewModel.onHostChange("192.168.1.1")
+        viewModel.onStartPortChange("80")
+        viewModel.onEndPortChange("85")
 
-        viewModel.selectHistoryEntry(entry)
-
-        // Advance to let the scan complete
+        viewModel.startScan()
         advanceUntilIdle()
 
         val state = viewModel.uiState.value
-        assertEquals("192.168.1.100", state.host)
-        assertEquals("1", state.startPort)
-        assertEquals("100", state.endPort)
-        assertEquals(PortScannerProtocol.UDP, state.protocol)
-    }
+        assertFalse(state.isRunning)
+        assertTrue(state.isScanFinished)
+     }
 
     @Test
     fun `history is deduplicated by host and port range`() = runTest {
-        Dispatchers.setMain(StandardTestDispatcher(testScheduler))
-        val viewModel = createViewModel()
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(testDispatcher)
+        val viewModel = createViewModel(testDispatcher)
         viewModel.onHostChange("192.168.1.1")
         viewModel.onStartPortChange("80")
         viewModel.onEndPortChange("100")


### PR DESCRIPTION
- Add isScanFinished state to PortScannerUiState so the banner
  stays visible after a scan completes with no open ports
- Show 'no open ports' message with error color when isScanFinished
  and discoveredPorts is empty
- Inject scanDispatcher into ViewModel for testability
- Add test verifying isScanFinished is set on scan completion
- Bump versionCode to 30, versionName to 3.43
