### PR TITLE
Fix: Handle malformed JSON gracefully in BulkConfigParser (Issue #24)

### DIFF
--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
@@ -151,7 +151,11 @@ object BulkConfigParser {
      */
     @Throws(IllegalArgumentException::class)
     fun parse(json: String): BulkConfig {
-        val root = JSONObject(json)
+        val root = try {
+            JSONObject(json)
+        } catch (e: org.json.JSONException) {
+            throw IllegalArgumentException("Malformed JSON: ${e.message}", e)
+        }
 
         val outputFile = runCatching {
             val path = root.optString("output-file", "")

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkConfigParserTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkConfigParserTest.kt
@@ -16,6 +16,9 @@ import org.junit.Test
  * Unit tests for the BulkActions JSON config parsing logic.
  * Mirrors the parsing code from BulkConfigParser to avoid Android API dependencies
  * in JVM unit tests (no Robolectric in this project).
+ *
+ * Note: Tests that verify malformed JSON handling must be done on actual Android devices
+ * since org.json.JSONObject behavior differs between JVM (mocked) and Android runtime.
  */
 class BulkConfigParserTest {
 


### PR DESCRIPTION
## Summary

This PR fixes issue #24 where malformed JSON causes the app to crash.

## Problem

When a Bulk Actions config JSON is malformed (e.g., missing closing brace), the app crashes with `org.json.JSONException` because `JSONObject(json)` throws an uncaught exception.

Example of malformed JSON that previously crashed the app:
```json
{
  "output-file": "/sdcard/Download/",
  "timeout": "421",
  "run": {
    "test1": "port-scan -p 2002 10.0.0.1"
}
```

## Solution

Added a try-catch block in `BulkConfigParser.parse()` to catch `JSONException` and convert it to `IllegalArgumentException` with a descriptive error message:

```kotlin
val root = try {
    JSONObject(json)
} catch (e: org.json.JSONException) {
    throw IllegalArgumentException("Malformed JSON: ${e.message}", e)
}
```

This ensures:
- Malformed JSON doesn't crash the app
- Users see a user-friendly error message instead of a crash
- The existing error handling in `BulkActionsViewModel` catches the exception and displays it via `validationMessage`

## Changes

- **app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt**: Added try-catch around `JSONObject(json)` to handle `JSONException`
- **app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkConfigParserTest.kt**: Added note explaining why direct malformed JSON tests require Android runtime

## Testing

All existing unit tests pass. The fix is minimal and focused on error handling - no logic changes.

Closes #24
