### PR TITLE
Fix: Handle malformed JSON gracefully in BulkConfigParser

### DIFF
--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
@@ -151,7 +151,11 @@ object BulkConfigParser {
      */
     @Throws(IllegalArgumentException::class)
     fun parse(json: String): BulkConfig {
-        val root = JSONObject(json)
+        val root = try {
+            JSONObject(json)
+        } catch (e: org.json.JSONException) {
+            throw IllegalArgumentException("Malformed JSON: ${e.message}", e)
+        }
 
         val outputFile = runCatching {
             val path = root.optString("output-file", "")

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkConfigParserTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/BulkConfigParserTest.kt
@@ -16,6 +16,9 @@ import org.junit.Test
  * Unit tests for the BulkActions JSON config parsing logic.
  * Mirrors the parsing code from BulkConfigParser to avoid Android API dependencies
  * in JVM unit tests (no Robolectric in this project).
+ *
+ * Note: Tests that verify malformed JSON handling must be done on actual Android devices
+ * since org.json.JSONObject behavior differs between JVM (mocked) and Android runtime.
  */
 class BulkConfigParserTest {
 


### PR DESCRIPTION
When JSON envelope is malformed (e.g., missing closing brace), the app now catches org.json.JSONException and converts it to IllegalArgumentException with a descriptive error message instead of crashing.

Changes:
- BulkActionsRepository.kt: Added try-catch around JSONObject(json) to handle JSONException and rethrow as IllegalArgumentException
- BulkConfigParserTest.kt: Added note explaining why direct malformed JSON tests require Android runtime (JVM org.json behaves differently)

This ensures users see a user-friendly error message instead of a crash when loading invalid JSON configs, especially important for ADB automation scripts that may generate malformed configs.

Fixes #24