### PR TITLE
feat(device-info): Add multiple IMEIs, storage used, and memory used

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
      <!-- Required for NTP UDP packet exchange -->
      <uses-permission android:name="android.permission.INTERNET" />
@@ -12,6 +13,7 @@
      <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
      <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
      <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+     <!-- https://developer.android.com/about/versions/10/privacy/changes#non-resettable-device-ids -->
      <!-- Bulk Actions: write output file (scoped storage on Android 10+ handles this, but needed for older) -->
      <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
      <!-- Read config files from shared storage (Android 13+ requires this) -->

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/BulkActionsRepository.kt
@@ -826,7 +826,13 @@ class BulkActionsRepository(
                     add("  Charging: ${di.isCharging ?: "N/A"}")
                     add("  Battery Health: ${di.batteryHealth ?: "N/A"}")
                     add("  Time Since Reboot: ${di.timeSinceReboot}")
-                    add("  IMEI: ${di.imei ?: "Restricted by Android 10+"}")
+                    if (di.imeiList.isEmpty()) {
+                        add("  IMEI: Restricted by Android 10+")
+                    } else {
+                        di.imeiList.forEachIndexed { index, imei ->
+                            add("  IMEI Slot ${index + 1}: $imei")
+                        }
+                    }
                     add("  Serial: ${di.serialNumber ?: "Restricted by Android 10+"}")
                     add("  ICCID: ${di.iccid ?: "Restricted by Android 10+"}")
                     add("  Total RAM: ${di.totalRam ?: "N/A"}")

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/deviceinfo/DeviceInfoModels.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/deviceinfo/DeviceInfoModels.kt
@@ -7,7 +7,7 @@ package io.github.mobilutils.ntp_dig_ping_more.deviceinfo
 data class DeviceInfo(
     // ── Required data points ──────────────────────────────────────────
     val deviceName: String? = null,
-    val imei: String? = null,
+    val imeiList: List<String> = emptyList(),
     val serialNumber: String? = null,
     val iccid: String? = null,
     val deviceTime: String? = null,
@@ -32,8 +32,10 @@ data class DeviceInfo(
     val batteryHealth: String? = null,
     val totalRam: String? = null,
     val availableRam: String? = null,
+    val usedRam: String? = null,
     val totalStorage: String? = null,
     val availableStorage: String? = null,
+    val usedStorage: String? = null,
     val cpuAbi: List<String> = emptyList(),
     val activeNetworkType: String? = null,
 )

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/deviceinfo/DeviceInfoScreen.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/deviceinfo/DeviceInfoScreen.kt
@@ -347,7 +347,9 @@ private fun DeviceInfoContent(
                 icon = Icons.Filled.Smartphone,
                 items = listOfNotNull(
                     InfoItem(stringResource(R.string.device_info_field_device), deviceInfo.deviceName),
-                    InfoItem(stringResource(R.string.device_info_field_imei), deviceInfo.imei),
+                    *deviceInfo.imeiList.mapIndexed { index, imei ->
+                        InfoItem(stringResource(R.string.device_info_field_imei_slot, index + 1), imei)
+                    }.toTypedArray(),
                     InfoItem(stringResource(R.string.device_info_field_serial), deviceInfo.serialNumber),
                     InfoItem(stringResource(R.string.device_info_field_iccid), deviceInfo.iccid),
                     InfoItem(stringResource(R.string.device_info_field_android_version), deviceInfo.androidVersion),
@@ -428,10 +430,22 @@ private fun DeviceInfoContent(
                 title = stringResource(R.string.device_info_section_memory_storage),
                 icon = Icons.Filled.Memory,
                 items = listOfNotNull(
-                    InfoItem(stringResource(R.string.device_info_field_total_ram), deviceInfo.totalRam),
-                    InfoItem(stringResource(R.string.device_info_field_available_ram), deviceInfo.availableRam),
-                    InfoItem(stringResource(R.string.device_info_field_total_storage), deviceInfo.totalStorage),
-                    InfoItem(stringResource(R.string.device_info_field_available_storage), deviceInfo.availableStorage),
+                    InfoItem(stringResource(R.string.device_info_field_ram), 
+                        buildString {
+                            append("Total: ${deviceInfo.totalRam ?: stringResource(R.string.common_label_unavailable)}")
+                            if (deviceInfo.availableRam != null || deviceInfo.usedRam != null) {
+                                append(" | Available: ${deviceInfo.availableRam ?: stringResource(R.string.common_label_unavailable)}")
+                                deviceInfo.usedRam?.let { append(" | Used: $it") }
+                            }
+                        }),
+                    InfoItem(stringResource(R.string.device_info_field_storage),
+                        buildString {
+                            append("Total: ${deviceInfo.totalStorage ?: stringResource(R.string.common_label_unavailable)}")
+                            if (deviceInfo.availableStorage != null || deviceInfo.usedStorage != null) {
+                                append(" | Available: ${deviceInfo.availableStorage ?: stringResource(R.string.common_label_unavailable)}")
+                                deviceInfo.usedStorage?.let { append(" | Used: $it") }
+                            }
+                        }),
                 )
             )
         }
@@ -776,7 +790,7 @@ private fun DeviceInfoScreenPreview() {
         DeviceInfoContent(
             deviceInfo = DeviceInfo(
                 deviceName = "Google Pixel 7",
-                imei = "35 123456 789012 3",
+                imeiList = listOf("35 123456 789012 3", "35 987654 321098 7"),
                 serialNumber = "Restricted by Android 10+",
                 iccid = "8901 2601 2345 6789 0123",
                 deviceTime = "2026-04-17 14:30:00",
@@ -798,8 +812,10 @@ private fun DeviceInfoScreenPreview() {
                 batteryHealth = "Good",
                 totalRam = "8.0 GB",
                 availableRam = "3.2 GB",
+                usedRam = "4.8 GB",
                 totalStorage = "128.0 GB",
                 availableStorage = "45.3 GB",
+                usedStorage = "82.7 GB",
                 cpuAbi = listOf("arm64-v8a", "armeabi-v7a", "armeabi"),
                 activeNetworkType = "Wi-Fi",
             )

--- a/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/deviceinfo/SystemInfoRepository.kt
+++ b/app/src/main/java/io/github/mobilutils/ntp_dig_ping_more/deviceinfo/SystemInfoRepository.kt
@@ -20,6 +20,8 @@ import android.os.Environment
 import android.os.PowerManager
 import android.os.SystemClock
 import android.provider.Settings
+import android.telephony.SubscriptionInfo
+import android.telephony.SubscriptionManager
 import android.telephony.TelephonyManager
 import androidx.annotation.RequiresApi
 import androidx.annotation.RequiresPermission
@@ -72,7 +74,7 @@ class SystemInfoRepository(
         return DeviceInfo(
             // Required data points
             deviceName = getDeviceName(),
-            imei = getImei(),
+            imeiList = getImeiList(),
             serialNumber = getSerialNumber(),
             iccid = getIccid(),
             deviceTime = getCurrentDeviceTime(),
@@ -99,8 +101,10 @@ class SystemInfoRepository(
             batteryHealth = getBatteryHealth(),
             totalRam = getTotalRam(),
             availableRam = getAvailableRam(),
+            usedRam = getUsedRam(),
             totalStorage = getTotalStorage(),
             availableStorage = getAvailableStorage(),
+            usedStorage = getUsedStorage(),
             cpuAbi = getCpuAbi(),
             activeNetworkType = getActiveNetworkType(),
         )
@@ -126,10 +130,10 @@ class SystemInfoRepository(
     /**
      * Gets the device IMEI (International Mobile Equipment Identity).
      *
-     * Android 10+ (API 29+) restriction:
-     *   - Requires READ_PHONE_STATE permission AND the app to be a device/profile owner,
-     *     OR have the READ_PRIVILEGED_PHONE_STATE permission (system apps only).
-     *   - For normal third-party apps on Android 10+, this returns null.
+     * Android 10+ (API 29+) behavior:
+     *   - Requires READ_PHONE_STATE permission.
+     *   - On many devices, normal apps can read IMEI even without device owner status.
+     *   - Returns null only if the call throws an exception or no cellular radio.
      *
      * Android 9 and below:
      *   - Requires READ_PHONE_STATE permission.
@@ -140,17 +144,54 @@ class SystemInfoRepository(
     @SuppressLint("MissingPermission", "HardwareIds")
     fun getImei(): String? {
         return try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                // Android 10+: IMEI is restricted to system/privileged apps
-                // Non-privileged apps get null or an exception
-                null
-            } else {
-                // Android 9 and below: use TelephonyManager.getDeviceId()
-                @Suppress("DEPRECATION")
-                telephonyManager.getDeviceId()
-            }
+            // Try to get IMEI using getDeviceId() - works on single-SIM devices
+            @Suppress("DEPRECATION")
+            telephonyManager.getDeviceId()
         } catch (e: Exception) {
             null
+        }
+    }
+
+    /**
+     * Gets the device IMEIs for all SIM slots.
+     *
+     * Android 10+ (API 29+) behavior:
+     *   - Requires READ_PHONE_STATE permission.
+     *   - On many devices, normal apps can read IMEI even without device owner status.
+     *   - Returns empty list only if the call throws an exception (permission denied, no SIM).
+     *
+     * Uses SubscriptionManager to get active subscriptions and TelephonyManager.getImei(slotId)
+     * for multi-SIM support.
+     */
+    @SuppressLint("MissingPermission", "HardwareIds")
+    fun getImeiList(): List<String> {
+        return try {
+            // Use SubscriptionManager to get all active SIM subscriptions
+            val subscriptionManager = SubscriptionManager.from(context)
+            val subscriptionInfoList = subscriptionManager.activeSubscriptionInfoList
+
+            if (subscriptionInfoList == null || subscriptionInfoList.isEmpty()) {
+                // No active subscriptions - no SIMs or permission denied
+                emptyList()
+            } else {
+                // For each subscription, get the IMEI
+                subscriptionInfoList.mapIndexed { index, _ ->
+                    try {
+                        // Use getImei(slotId) for multi-SIM support (API 23+)
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                            telephonyManager.getImei(index)
+                        } else {
+                            @Suppress("DEPRECATION")
+                            telephonyManager.getDeviceId()
+                        }
+                    } catch (e: Exception) {
+                        // IMEI access failed for this slot (permission denied, no SIM, etc.)
+                        null
+                    }
+                }.filterNotNull()
+            }
+        } catch (e: Exception) {
+            emptyList()
         }
     }
 
@@ -655,6 +696,22 @@ class SystemInfoRepository(
     }
 
     /**
+     * Used RAM in human-readable format.
+     */
+    fun getUsedRam(): String? {
+        return try {
+            val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+            val memInfo = ActivityManager.MemoryInfo()
+            activityManager.getMemoryInfo(memInfo)
+            // used = total - available
+            val usedBytes = memInfo.totalMem - memInfo.availMem
+            formatBytes(usedBytes)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
      * Total internal storage capacity.
      * Reads from /data partition (user-accessible storage).
      */
@@ -678,6 +735,21 @@ class SystemInfoRepository(
             val stat = android.os.StatFs(dataDir.path)
             val availableBytes = stat.availableBytes
             formatBytes(availableBytes)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Used internal storage.
+     */
+    fun getUsedStorage(): String? {
+        return try {
+            val dataDir = Environment.getDataDirectory()
+            val stat = android.os.StatFs(dataDir.path)
+            // used = total - available
+            val usedBytes = stat.totalBytes - stat.availableBytes
+            formatBytes(usedBytes)
         } catch (e: Exception) {
             null
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -334,8 +334,13 @@
     <string name="device_info_field_battery_no">No</string>
     <string name="device_info_field_total_ram">Total RAM</string>
     <string name="device_info_field_available_ram">Available RAM</string>
+    <string name="device_info_field_used_ram">Used RAM</string>
     <string name="device_info_field_total_storage">Total Storage</string>
     <string name="device_info_field_available_storage">Available Storage</string>
+    <string name="device_info_field_used_storage">Used Storage</string>
+    <string name="device_info_field_ram">Memory</string>
+    <string name="device_info_field_storage">Storage</string>
+    <string name="device_info_field_imei_slot">IMEI Slot %1$d</string>
     <string name="device_info_mdm_status_label">MDM Status</string>
     <string name="device_info_mdm_managed_badge">App is managed</string>
     <string name="device_info_mdm_managed_default">Managed (restrictions active)</string>

--- a/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/deviceinfo/DeviceInfoViewModelTest.kt
+++ b/app/src/test/java/io/github/mobilutils/ntp_dig_ping_more/deviceinfo/DeviceInfoViewModelTest.kt
@@ -27,7 +27,7 @@ class DeviceInfoViewModelTest {
 
     private val sampleDeviceInfo = DeviceInfo(
         deviceName = "Samsung Galaxy S21",
-        imei = null,
+        imeiList = emptyList(),
         serialNumber = "Restricted by Android 10+",
         iccid = "Restricted by Android 10+",
         deviceTime = "2024-01-15 10:30:00",
@@ -50,8 +50,10 @@ class DeviceInfoViewModelTest {
         batteryHealth = "Good",
         totalRam = "8.0 GB",
         availableRam = "3.2 GB",
+        usedRam = "4.8 GB",
         totalStorage = "128.0 GB",
         availableStorage = "64.5 GB",
+        usedStorage = "63.5 GB",
         cpuAbi = listOf("arm64-v8a", "armeabi-v7a"),
         activeNetworkType = "WiFi",
     )


### PR DESCRIPTION
- Replace single imei field with imeiList for multi-SIM support
- Add usedStorage and usedRam fields to DeviceInfo model
- Update SystemInfoRepository to calculate and read new values:
  * getImeiList() uses SubscriptionManager for all SIM slots
  * getUsedStorage() calculates total - available
  * getUsedRam() calculates total - available
- Update UI to show:
  * Multiple IMEI rows (IMEI Slot 1, Slot 2, etc.)
  * Combined storage row: Total | Available | Used
  * Combined memory row: Total | Available | Used
- Add new string labels for IMEI slots and combined fields
- Update test data and BulkActionsRepository to use new model
- Add comment about Android 10+ IMEI permission requirements